### PR TITLE
Update templates to use NetworkAttachmentDefinition

### DIFF
--- a/deployments/crdnetwork.yaml
+++ b/deployments/crdnetwork.yaml
@@ -2,21 +2,21 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
-  name: networks.kubernetes.cni.cncf.io
+  name: network-attachment-definitions.k8s.cni.cncf.io
 spec:
   # group name to use for REST API: /apis/<group>/<version>
-  group: kubernetes.cni.cncf.io
+  group: k8s.cni.cncf.io
   # version name to use for REST API: /apis/<group>/<version>
   version: v1
   # either Namespaced or Cluster
   scope: Namespaced
   names:
     # plural name to be used in the URL: /apis/<group>/<version>/<plural>
-    plural: networks
+    plural: network-attachment-definitions
     # singular name to be used as an alias on the CLI and for display
-    singular: network
+    singular: network-attachment-definition
     # kind is normally the CamelCased singular type. Your resource manifests use this.
-    kind: Network
+    kind: NetworkAttachmentDefinition
     # shortNames allow shorter string to match your resource on the CLI
     shortNames:
-    - net
+    - net-attach-def

--- a/deployments/pod-tc1.yaml
+++ b/deployments/pod-tc1.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     env: test
   annotations:
-      kubernetes.v1.cni.cncf.io/networks: sriov-net1
+    k8s.v1.cni.cncf.io/networks: sriov-net1
 spec:
   containers:
   - name: appcntr1 

--- a/deployments/pod-tc2.yaml
+++ b/deployments/pod-tc2.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     env: test
   annotations:
-      kubernetes.v1.cni.cncf.io/networks: sriov-net1
+    k8s.v1.cni.cncf.io/networks: sriov-net1
 spec:
   containers:
   - name: appcntr2 

--- a/deployments/pod-tc3.yaml
+++ b/deployments/pod-tc3.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     env: test
   annotations:
-      kubernetes.v1.cni.cncf.io/networks: sriov-net1
+    k8s.v1.cni.cncf.io/networks: sriov-net1
 spec:
   containers:
   - name: appcntr3 

--- a/deployments/sriov-crd.yaml
+++ b/deployments/sriov-crd.yaml
@@ -1,7 +1,9 @@
-apiVersion: "kubernetes.cni.cncf.io/v1"
-kind: Network
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
 metadata:
   name: sriov-net1
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: intel.com/sriov
 spec:
   config: '{
 	"type": "sriov",


### PR DESCRIPTION
This commits update the following templates to work with
multus v3.0 changes:

* deployments/crdnetwork.yaml
* deployments/sriov-crd.yaml
* deployments/pod-tc(1/2/3).yaml