### PR TITLE
allowing proxy-settings to be passed in for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM centos:centos7
 
 ADD . /usr/src/sriov-network-device-plugin
 
+ENV HTTP_PROXY $http_proxy
+ENV HTTPS_PROXY $https_proxy
 ENV INSTALL_PKGS "git golang make"
 RUN yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,19 @@ TESTPKGS = $(shell env GOPATH=$(GOPATH) $(GO) list -f '{{ if or .TestGoFiles .XT
 
 export GOPATH
 export GOBIN
+
 # Docker
 IMAGEDIR=$(BASE)/images
 DOCKERFILE=$(CURDIR)/Dockerfile
 TAG=nfvpe/sriov-device-plugin
+# Accept proxy settings for docker 
+DOCKERARGS=
+ifdef HTTP_PROXY
+	DOCKERARGS += --build-arg http_proxy=$(HTTP_PROXY)
+endif
+ifdef HTTPS_PROXY
+	DOCKERARGS += --build-arg https_proxy=$(HTTPS_PROXY)
+endif
 
 # Go tools
 GO      = go
@@ -137,11 +146,7 @@ vendor: glide.lock | $(BASE) ; $(info  retrieving dependencies...)
 # To pass proxy for Docker invoke it as 'make image HTTP_POXY=http://192.168.0.1:8080'
 .PHONY: image
 image: | $(BASE) ; $(info Building Docker image...)
-ifdef HTTP_PROXY
-	@docker build -t $(TAG) -f $(DOCKERFILE)  $(CURDIR) --build-arg http_proxy=$(HTTP_PROXY)
-else
-	@docker build -t $(TAG) -f $(DOCKERFILE)  $(CURDIR) 
-endif
+	@docker build -t $(TAG) -f $(DOCKERFILE)  $(CURDIR) $(DOCKERARGS)
 
 # Misc
 


### PR DESCRIPTION
This changes will allow proxy settings to be passed in for docker
as well as Env variable in Dockerfile.

simply invoke 'make image HTTP_PROXY=http://whateverhost:port'.

Change-Id: I4264b2a96d86a6feedee1b21a9f1bac8e74c8fc5