### PR TITLE
use 'make build' instead of 'make' in Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     cd /usr/src/sriov-network-device-plugin && \
     make clean && \
-    make && \
+    make build && \
     yum autoremove -y $INSTALL_PKGS && \
     yum clean all && \
     rm -rf /tmp/*


### PR DESCRIPTION
This commit allows 'make build' to build device plugin binary from local dependency instead of having to update packages before building. Also it keeps original 'make' behavior to run a "fmt", "lint" and "build".
This change is helpful when building device plugin binary from a local environment without internet access.