### PR TITLE
Use host PID namespace

### DIFF
--- a/images/sriovdp-daemonset.yaml
+++ b/images/sriovdp-daemonset.yaml
@@ -21,6 +21,7 @@ spec:
         tier: node
         app: sriovdp
     spec:
+      hostPID: true
       nodeSelector:
         beta.kubernetes.io/arch: amd64
       tolerations:


### PR DESCRIPTION
This fixes plugin startup failure:

error starting resource servers listen unix
/var/lib/kubelet/device-plugins/sriov.sock: bind: address already in use