### PR TITLE
fix endless waiting

### DIFF
--- a/cmd/sriovdp/sriov-device-plugin.go
+++ b/cmd/sriovdp/sriov-device-plugin.go
@@ -400,7 +400,6 @@ func (sm *sriovManager) ListAndWatch(empty *pluginapi.Empty, stream pluginapi.De
 	for {
 		select {
 		case <-time.After(10 * time.Second):
-			continue
 		case <-sm.termSignal:
 			glog.Infof("Terminate signal received, exiting ListAndWatch.")
 			return nil

--- a/cmd/sriovdp/sriov-device-plugin.go
+++ b/cmd/sriovdp/sriov-device-plugin.go
@@ -398,12 +398,6 @@ func (sm *sriovManager) ListAndWatch(empty *pluginapi.Empty, stream pluginapi.De
 	// Probes device state every 10 seconds and updates if changed.
 	// Terminates when termSignal received.
 	for {
-		select {
-		case <-time.After(10 * time.Second):
-		case <-sm.termSignal:
-			glog.Infof("Terminate signal received, exiting ListAndWatch.")
-			return nil
-		}
 		if sm.Probe() {
 			resp := new(pluginapi.ListAndWatchResponse)
 			for _, dev := range sm.devices {
@@ -415,6 +409,14 @@ func (sm *sriovManager) ListAndWatch(empty *pluginapi.Empty, stream pluginapi.De
 				sm.grpcServer.Stop()
 				return err
 			}
+		}
+
+		select {
+		case <-time.After(10 * time.Second):
+			continue
+		case <-sm.termSignal:
+			glog.Infof("Terminate signal received, exiting ListAndWatch.")
+			return nil
 		}
 	}
 	return nil


### PR DESCRIPTION
Previously sm.Probe() is evaluated first in the
ListAndWatch for loop so there is no problem by
adding continue in the select case of 10 seconds;
but with recent change, sm.Probe() is moved under
select which causes an endless 10 seconds waiting
and Probe() is never invoked until the termSignal
is received. Fix it by removing continue.