### PR TITLE
Env variable name with proposed scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,35 @@
 # SRIOV Network device plugin for Kubernetes
+
 ## Table of Contents
 
 - [SRIOV Network device plugin](#sriov-network-device-plugin)
 - [Features](#features)
 - [Prerequisites](#prerequisites)
-	-  [Supported SRIOV NICs](#supported-sriov-nics)
+  - [Supported SRIOV NICs](#supported-sriov-nics)
 - [Quick Start](#quick-start)
-	- [Network Object CRDs](#network-object-crds)
-	- [Build and configure Multus](#build-and-configure-multus) 
-	- [Build SRIOV CNI](#build-sriov-cni)
-	- [Build and run SRIOV network device plugin](#build-and-run-sriov-network-device-plugin)
-        - [Configurations](#configurations)
-                 - [Config parameters](#config-parameters)
-                 - [Command line arguments](#command-line-arguments)
-                 - [Assumptions](#assumptions)
-                 - [Workflow](#workflow)
-        - [Example deployments](#example-deployments)
-	- [Testing SRIOV workloads](#testing-sriov-workloads)
-		 - [Deploy test Pod](#deploy-test-pod)
-		 - [Verify Pod network interfaces](#verify-pod-network-interfaces)
-		 - [Verify Pod routing table](#verify-pod-routing-table)		 
+  - [Network Object CRDs](#network-object-crds)
+  - [Build and configure Multus](#build-and-configure-multus)
+  - [Build SRIOV CNI](#build-sriov-cni)
+  - [Build and run SRIOV network device plugin](#build-and-run-sriov-network-device-plugin)
+  - [Configurations](#configurations)
+    - [Config parameters](#config-parameters)
+    - [Command line arguments](#command-line-arguments)
+    - [Assumptions](#assumptions)
+    - [Workflow](#workflow)
+  - [Example deployments](#example-deployments)
+    - [Testing SRIOV workloads](#testing-sriov-workloads)
+      - [Deploy test Pod](#deploy-test-pod)
+      - [Verify Pod network interfaces](#verify-pod-network-interfaces)
+      - [Verify Pod routing table](#verify-pod-routing-table)
+    - [Pod device information](#pod-device-information)
 - [Issues and Contributing](#issues-and-contributing)
 
 ## SRIOV Network Device Plugin
+
 The SRIOV network device plugin is Kubernetes device plugin for discovering and advertising SRIOV network virtual functions (VFs) in a Kubernetes host. 
 
 ## Features
+
 - Handles SRIOV capable/not-capable devices (NICs and Accelerators alike)
 - Supports devices with both Kernel and userspace(uio and VFIO) drivers
 - Supports PF bound to DPDK driver to meet certain use-cases
@@ -54,6 +58,7 @@ This implementation follows the design discuessed in [this proposal document](ht
 Please follow the Multus [Quick Start](#quick-start) for multi network interface support in Kubernetes.
 
 ### Supported SRIOV NICs
+
 The following  NICs were tested with this implementation. However, other SRIOV capable NICs should work as well.
 -  Intel® Ethernet Controller X710 Series 4x10G
 		- PF driver : v2.4.6
@@ -65,12 +70,15 @@ The following  NICs were tested with this implementation. However, other SRIOV c
 > please refer to Intel download center for installing latest [Intel-® 82599ES 10 Gigabit Ethernet](https://ark.intel.com/products/41282/Intel-82599ES-10-Gigabit-Ethernet-Controller) drivers
 
 ## Quick Start
+
 This section explains an exmaple deployment of SRIOV Network device plugin in Kubernetes. Required YAML files can be found in [deployments/](deployments/) directory.
 
 ### Network Object CRDs
+
 Multus uses Custom Resource Definitions(CRDs) for defining additional network attachements. These network attachment CRDs follow the standards defined by K8s Network Plumbing Working Group(NPWG). Please refer to [Multus documentation](https://github.com/intel/multus-cni/blob/master/README.md) for more information.
 
 ### Build and configure Multus
+
 1. Compile Multus executable:
 ```
 $ git clone https://github.com/intel/multus-cni.git
@@ -78,7 +86,7 @@ $ cd multus-cni
 $ ./build
 $ cp bin/multus /opt/cni/bin
 ```
- 2. Copy the multus Configuration file from the Deployments folder to the CNI Configuration diectory
+2. Copy the multus Configuration file from the Deployments folder to the CNI Configuration diectory
 ```
 $ cp deployments/cni-conf.json /etc/cni/net.d/
 ```
@@ -89,7 +97,8 @@ $ kubectl create -f deployments/crdnetwork.yaml
 ```
 
 ### Build SRIOV CNI
- 1. Compile SRIOV-CNI (dev/k8s-deviceid-model branch):
+
+1. Compile SRIOV-CNI (dev/k8s-deviceid-model branch):
 ```
 $ git clone https://github.com/intel/sriov-cni.git
 $ cd sriov-cni
@@ -98,10 +107,11 @@ $ git checkout dev/k8s-deviceid-model
 $ ./build
 $ cp bin/sriov /opt/cni/bin
 ```
- 2. Create the SRIOV Network CRD
+2. Create the SRIOV Network CRD
 ```
 $ kubectl create -f deployments/sriov-crd.yaml
 ```
+
 ### Build and run SRIOV network device plugin
 
  1. Clone the sriov-network-device-plugin
@@ -125,6 +135,7 @@ $ make image
 ## Configurations
 
 ### Config parameters
+
 This plugin creates device plugin endpoints based on the configurations given in file `/etc/pcidp/config.json`. This configuration file is in json format as shown below:
 
 ```json
@@ -146,6 +157,7 @@ This plugin creates device plugin endpoints based on the configurations given in
     ]
 }
 ```
+
 `"resourceList"` should contain a list of config objects. Each config object may consist of following fields:
 
 |     Field      | Required |                    Description                    |                       Type - Accepted values                        |         Example          |
@@ -155,8 +167,8 @@ This plugin creates device plugin endpoints based on the configurations given in
 | "sriovMode"    | No       | Whether the root devices are SRIOV capable or not | `bool` - true OR false[default]                                     | `true`                   |
 | "deviceType"   | No       | Device driver type                                | `string` - "netdevice"\|"uio"\|"vfio"                               | `"netdevice"`            |
 
-
 ### Command line arguments
+
 This plugin accepts the following optional run-time command line arguments:
 
 ```bash
@@ -184,6 +196,7 @@ Usage of ./sriovdp:
 ```
 
 ### Assumptions
+
 This plugin does not bind or unbind any driver to any device whether it's PFs or VFs. It also doesn't create Virtual functions either. Usually, the virtual functions are created at boot time when kernel module for the device is loaded. Required device drivers could be loaded on system boot-up time by white-listing/black-listing the right modules. But plugin needs to be aware of the driver type of the resources(i.e. devices) that it is registering as K8s extended resource so that it's able to create appropriate Device Specs for the requested resource.
 
 For exmaple, if the driver type is uio(i.e. igb_uio.ko) then there are specific device files to add in Device 
@@ -194,6 +207,7 @@ The idea here is, user creates a resource config for each resource pool as shown
 If `"sriovMode": true` is given for a resource config then plugin will look for virtual functions(VFs) for all the devices listed in `"rootDevices"` and export the discovered VFs as allocatable extended resource list. Otherwise, plugin will export the root devices themsleves as the allocatable extended resources.
 
 ### Workflow
+
 - Load device's (Physical funtion if it is SRIOV capable) kernel module and bind the driver to the PF
 - Create required Virtual functions
 - Bind all VF with right drivers
@@ -219,6 +233,7 @@ $ kubectl get node node1 -o json | jq '.status.allocatable'
 ```
 
 ## Example deployments
+
 We assume that you have working K8s cluster configured with Mutlus meta plugin for multi-network support. Please see [Additional information](#additional-information) section for more informaiton on required CNI plugins.
 
 The [images](./images) directory contains example Docker file, sample specs along with build scripts to deploy the SRIOV device plugin as daemonset. Please see [README.md](./images/README.md) building docker the image.
@@ -227,8 +242,11 @@ There are some example Pod specs and related network CRD yaml files can be found
 
 
 ### Testing SRIOV workloads
+
 Leave the sriov device plugin running and open a new terminal session for following steps.
+
 #### Deploy test Pod
+
 ````
 $ kubectl create -f pod-tc1.yaml
 pod "testpod1" created
@@ -238,7 +256,9 @@ NAME                  READY     STATUS    RESTARTS   AGE
 sriov-device-plugin   1/1       Running   0          7h
 testpod1        	  1/1       Running   0          3s
 ````
+
 #### Verify Pod network interfaces
+
 ````
 $ kubectl exec -it testpod1 -- ip addr show
 
@@ -255,7 +275,9 @@ $ kubectl exec -it testpod1 -- ip addr show
     inet 10.56.217.179/24 scope global net0
        valid_lft forever preferred_lft forever
 ````
+
 #### Verify Pod routing table
+
 ````
 $ kubectl exec -it testpod1 -- route -n
 
@@ -267,7 +289,15 @@ Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
 192.168.74.0    0.0.0.0         255.255.255.0   U     0      0        0 eth0
 ````
 
+### Pod device information
+
+The allocated device information are exported in Container's environment variable. The variable name is `PCIDEVICE_` appended with full extended resource name(i.e. intel.com/sriov) which is capitailzed and any special characters(".", "/") are replaced with underscore("_"). In case of multiple devices from same extended resource pool, the device IDs are delimited with commas(",").
+
+For example, if 2 devices are allocated from `intel.com/sriov` extended resource then the allocated device information will be found in following env variable:
+`PCIDEVICE_INTEL_COM_SRIOV=0000:03:02.1,0000:03:04.3`
+
 ## Issues and Contributing
+
 We welcome your feedback and contributions to this project. Please see the [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines. 
 
 Copyright 2018 © Intel Corporation.

--- a/pkg/resources/genericPool.go
+++ b/pkg/resources/genericPool.go
@@ -27,15 +27,19 @@ import (
 	GetMounts()
 */
 type genericResourcePool struct {
+	resourcePool
 }
 
 func newGenericResourcePool(rc *types.ResourceConfig) types.ResourcePool {
-	return &resourcePool{
-		config:        rc,
-		devices:       make(map[string]*pluginapi.Device),
-		deviceFiles:   make(map[string]string),
-		IBaseResource: &genericResourcePool{},
+	this := &genericResourcePool{
+		resourcePool: resourcePool{
+			config:      rc,
+			devices:     make(map[string]*pluginapi.Device),
+			deviceFiles: make(map[string]string),
+		},
 	}
+	this.IBaseResource = this
+	return this
 }
 
 // Overrides GetDeviceFile() method
@@ -45,7 +49,7 @@ func (rp *genericResourcePool) GetDeviceFile(dev string) (devFile string, err er
 	return // empty string
 }
 
-func (rp *genericResourcePool) GetEnvs(resourceName string, deviceIDs []string) map[string]string {
+func (rp *genericResourcePool) GetEnvs(deviceIDs []string) map[string]string {
 	glog.Infof("generic GetEnvs() called")
 	envs := make(map[string]string)
 	values := ""
@@ -57,7 +61,7 @@ func (rp *genericResourcePool) GetEnvs(resourceName string, deviceIDs []string) 
 		}
 		values += " "
 	}
-	envs[resourceName] = values
+	envs[rp.config.ResourceName] = values
 	return envs
 }
 

--- a/pkg/resources/genericPool.go
+++ b/pkg/resources/genericPool.go
@@ -59,7 +59,7 @@ func (rp *genericResourcePool) GetEnvs(deviceIDs []string) map[string]string {
 		if i == lastIndex {
 			break
 		}
-		values += " "
+		values += ","
 	}
 	envs[rp.config.ResourceName] = values
 	return envs

--- a/pkg/resources/netDevicePool.go
+++ b/pkg/resources/netDevicePool.go
@@ -61,7 +61,7 @@ func (rp *netDevicePool) GetEnvs(deviceIDs []string) map[string]string {
 		if i == lastIndex {
 			break
 		}
-		values += " "
+		values += ","
 	}
 	envs[rp.config.ResourceName] = values
 	return envs

--- a/pkg/resources/netDevicePool.go
+++ b/pkg/resources/netDevicePool.go
@@ -29,15 +29,19 @@ import (
 	Probe()
 */
 type netDevicePool struct {
+	resourcePool
 }
 
 func newNetDevicePool(rc *types.ResourceConfig) types.ResourcePool {
-	return &resourcePool{
-		config:        rc,
-		devices:       make(map[string]*pluginapi.Device),
-		deviceFiles:   make(map[string]string),
-		IBaseResource: &netDevicePool{},
+	this := &netDevicePool{
+		resourcePool: resourcePool{
+			config:      rc,
+			devices:     make(map[string]*pluginapi.Device),
+			deviceFiles: make(map[string]string),
+		},
 	}
+	this.IBaseResource = this
+	return this
 }
 
 // Overrides GetDeviceFile() method
@@ -47,7 +51,7 @@ func (rp *netDevicePool) GetDeviceFile(dev string) (devFile string, err error) {
 	return // empty string
 }
 
-func (rp *netDevicePool) GetEnvs(resourceName string, deviceIDs []string) map[string]string {
+func (rp *netDevicePool) GetEnvs(deviceIDs []string) map[string]string {
 	glog.Infof("generic GetEnvs() called")
 	envs := make(map[string]string)
 	values := ""
@@ -59,7 +63,7 @@ func (rp *netDevicePool) GetEnvs(resourceName string, deviceIDs []string) map[st
 		}
 		values += " "
 	}
-	envs[resourceName] = values
+	envs[rp.config.ResourceName] = values
 	return envs
 }
 

--- a/pkg/resources/pool_stub.go
+++ b/pkg/resources/pool_stub.go
@@ -43,7 +43,6 @@ func newResourcePool(rc *types.ResourceConfig, bScript string) types.ResourcePoo
 }
 
 func (rp *resourcePool) GetConfig() *types.ResourceConfig {
-	// Not implemented
 	return rp.config
 }
 

--- a/pkg/resources/server.go
+++ b/pkg/resources/server.go
@@ -86,7 +86,7 @@ func (rs *resourceServer) Allocate(ctx context.Context, rqt *pluginapi.AllocateR
 	for _, container := range rqt.ContainerRequests {
 		containerResp := new(pluginapi.ContainerAllocateResponse)
 		containerResp.Devices = rs.resourcePool.GetDeviceSpecs(rs.resourcePool.GetDeviceFiles(), container.DevicesIDs)
-		containerResp.Envs = rs.resourcePool.GetEnvs(rs.resourcePool.GetResourceName(), container.DevicesIDs)
+		containerResp.Envs = rs.resourcePool.GetEnvs(container.DevicesIDs)
 		containerResp.Mounts = rs.resourcePool.GetMounts()
 		resp.ContainerResponses = append(resp.ContainerResponses, containerResp)
 	}

--- a/pkg/resources/uioPool.go
+++ b/pkg/resources/uioPool.go
@@ -27,15 +27,19 @@ import (
 	GetMounts()
 */
 type uioResourcePool struct {
+	resourcePool
 }
 
 func newUioResourcePool(rc *types.ResourceConfig) types.ResourcePool {
-	return &resourcePool{
-		config:        rc,
-		devices:       make(map[string]*pluginapi.Device),
-		deviceFiles:   make(map[string]string),
-		IBaseResource: &uioResourcePool{},
+	this := &uioResourcePool{
+		resourcePool: resourcePool{
+			config:      rc,
+			devices:     make(map[string]*pluginapi.Device),
+			deviceFiles: make(map[string]string),
+		},
 	}
+	this.IBaseResource = this
+	return this
 }
 
 // Overrides GetDeviceFile() method
@@ -43,7 +47,7 @@ func (rp *uioResourcePool) GetDeviceFile(dev string) (devFile string, err error)
 	return utils.GetUIODeviceFile(dev)
 }
 
-func (rp *uioResourcePool) GetEnvs(resourceName string, deviceIDs []string) map[string]string {
+func (rp *uioResourcePool) GetEnvs(deviceIDs []string) map[string]string {
 	envs := make(map[string]string)
 	values := ""
 	lastIndex := len(deviceIDs) - 1
@@ -54,7 +58,7 @@ func (rp *uioResourcePool) GetEnvs(resourceName string, deviceIDs []string) map[
 		}
 		values += " "
 	}
-	envs[resourceName] = values
+	envs[rp.config.ResourceName] = values
 	return envs
 }
 func (rp *uioResourcePool) GetMounts() []*pluginapi.Mount {

--- a/pkg/resources/uioPool.go
+++ b/pkg/resources/uioPool.go
@@ -56,7 +56,7 @@ func (rp *uioResourcePool) GetEnvs(deviceIDs []string) map[string]string {
 		if i == lastIndex {
 			break
 		}
-		values += " "
+		values += ","
 	}
 	envs[rp.config.ResourceName] = values
 	return envs

--- a/pkg/resources/vfioPool.go
+++ b/pkg/resources/vfioPool.go
@@ -28,16 +28,21 @@ import (
 	GetMounts()
 */
 type vfioResourcePool struct {
+	resourcePool
 	vfioMount string
 }
 
 func newVfioResourcePool(rc *types.ResourceConfig) types.ResourcePool {
-	return &resourcePool{
-		config:        rc,
-		devices:       make(map[string]*pluginapi.Device),
-		deviceFiles:   make(map[string]string),
-		IBaseResource: &vfioResourcePool{vfioMount: "/dev/vfio/vfio"},
+	this := &vfioResourcePool{
+		resourcePool: resourcePool{
+			config:      rc,
+			devices:     make(map[string]*pluginapi.Device),
+			deviceFiles: make(map[string]string),
+		},
+		vfioMount: "/dev/vfio/vfio",
 	}
+	this.IBaseResource = this
+	return this
 }
 
 // Overrides GetDeviceFile() method
@@ -45,7 +50,7 @@ func (rp *vfioResourcePool) GetDeviceFile(dev string) (devFile string, err error
 	return utils.GetVFIODeviceFile(dev)
 }
 
-func (rp *vfioResourcePool) GetEnvs(resourceName string, deviceIDs []string) map[string]string {
+func (rp *vfioResourcePool) GetEnvs(deviceIDs []string) map[string]string {
 	glog.Infof("vfio GetEnvs() called")
 	envs := make(map[string]string)
 	values := ""
@@ -57,7 +62,7 @@ func (rp *vfioResourcePool) GetEnvs(resourceName string, deviceIDs []string) map
 		}
 		values += " "
 	}
-	envs[resourceName] = values
+	envs[rp.config.ResourceName] = values
 	return envs
 }
 

--- a/pkg/resources/vfioPool.go
+++ b/pkg/resources/vfioPool.go
@@ -60,7 +60,7 @@ func (rp *vfioResourcePool) GetEnvs(deviceIDs []string) map[string]string {
 		if i == lastIndex {
 			break
 		}
-		values += " "
+		values += ","
 	}
 	envs[rp.config.ResourceName] = values
 	return envs

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -74,7 +74,7 @@ type ResourcePool interface {
 type IBaseResource interface {
 	GetDeviceFile(dev string) (devFile string, err error)
 	GetDeviceSpecs(deviceFiles map[string]string, deviceIDs []string) []*pluginapi.DeviceSpec
-	GetEnvs(resourceName string, deviceIDs []string) map[string]string
+	GetEnvs(deviceIDs []string) map[string]string
 	GetMounts() []*pluginapi.Mount
 	// Probe does device health-check and update devices and returns 'true' if any of device in resource pool changed
 	Probe(*ResourceConfig, map[string]*pluginapi.Device) bool


### PR DESCRIPTION
This PR is based on [discussion](https://github.com/intel/sriov-network-device-plugin/pull/26#discussion_r229915970) on Env variable naming scheme.

Env variable with device IDs will be exported in following format: `PCIDEVICE_INTEL_COM_NET_A=0000:87:10.0;0000:87:11.6`
