### PR TITLE
Pull the latest image for daemon set

### DIFF
--- a/images/sriovdp-daemonset.yaml
+++ b/images/sriovdp-daemonset.yaml
@@ -31,7 +31,6 @@ spec:
       containers:
       - name: kube-sriovdp
         image: nfvpe/sriov-device-plugin:latest
-        imagePullPolicy: Never
         args:
         - --log-level=10
         securityContext:


### PR DESCRIPTION
With policy = Never, the image won't be pulled by kubelet, meaning the
deployment will fail to start pods due to missing image in registry.