### PR TITLE
Don't use bash to run /entrypoint.sh

### DIFF
--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -6,14 +6,14 @@ SRIOV_DP_SYS_BINARY_DIR="/usr/bin/"
 LOG_DIR=""
 LOG_LEVEL=10
 
-function usage()
+usage()
 {
-    echo -e "This is an entrypoint script for SR-IOV Network Device Plugin"
-    echo -e ""
-    echo -e "./entrypoint.sh"
-    echo -e "\t-h --help"
-    echo -e "\t--log-dir=$LOG_DIR"
-    echo -e "\t--log-level=$LOG_LEVEL"
+    /bin/echo -e "This is an entrypoint script for SR-IOV Network Device Plugin"
+    /bin/echo -e ""
+    /bin/echo -e "./entrypoint.sh"
+    /bin/echo -e "\t-h --help"
+    /bin/echo -e "\t--log-dir=$LOG_DIR"
+    /bin/echo -e "\t--log-level=$LOG_LEVEL"
 }
 
 while [ "$1" != "" ]; do


### PR DESCRIPTION
Now that we switched to alpine that doesn't have bash installed, the
script fails to execute.

There were a bunch of bashisms in the script (detected by
checkbashisms tool), specifically:

1. built-in posix shell echo doesn't support -e. To overcome this, we
execute /bin/echo that is busybox version of echo guaranteed to support
it.

2. `function` keyword is not part of posix shell syntax. Just remove it.

With that, we should be able to safely switch shebang to /bin/sh.