### PR TITLE
ignore error when no SR-IOV capable PF is found

### DIFF
--- a/cmd/sriovdp/sriov-device-plugin.go
+++ b/cmd/sriovdp/sriov-device-plugin.go
@@ -80,8 +80,8 @@ func getSriovPfList() ([]string, error) {
 	}
 
 	if len(netDevices) < 1 {
-		glog.Errorf("Error. No network device found in %s directory", netDirectory)
-		return sriovNetDevices, err
+		glog.Warningf("Warning. No network device found in %s directory", netDirectory)
+		return sriovNetDevices, nil
 	}
 
 	for _, dev := range netDevices {
@@ -147,14 +147,13 @@ func (sm *sriovManager) discoverNetworks() error {
 
 	// Get a list of SRIOV capable NICs in the host
 	pfList, err := getSriovPfList()
-
 	if err != nil {
 		return err
 	}
 
 	if len(pfList) < 1 {
-		glog.Errorf("Error. No SRIOV network device found")
-		return fmt.Errorf("Error. No SRIOV network device found")
+		glog.Warningf("Warning. No SRIOV network device found")
+		return nil
 	}
 
 	for _, dev := range pfList {


### PR DESCRIPTION
When SR-IOV device plugin runs on node without SR-IOV configured devices, it'll still advertise the resourceName of devices but with zero capacity and allocatable device.

Fixes #62