### PR TITLE
Modify template pod-sriovdp.yaml to mount default config file

### DIFF
--- a/deployments/pod-sriovdp.yaml
+++ b/deployments/pod-sriovdp.yaml
@@ -16,6 +16,9 @@ spec:
     - mountPath: /sys/class/net
       name: net
       readOnly: true
+    - mountPath: /etc/pcidp/
+      name: config
+      readOnly: true
   volumes:
   - name: devicesock 
     hostPath:
@@ -24,5 +27,8 @@ spec:
   - name: net
     hostPath:
       path: /sys/class/net
+  - name: config
+    hostPath:
+      path: /etc/pcidp/
   hostNetwork: true
   hostPID: true


### PR DESCRIPTION
Add mount for /etc/pcidp/config.json the default configuration
file, which was casuing pod status to be "RunContainerError" when
running the plugin as pod

Fixes #73