### PR TITLE
allow specifying NIC models to be discovered

### DIFF
--- a/deployments/pod-tc1.yaml
+++ b/deployments/pod-tc1.yaml
@@ -15,6 +15,6 @@ spec:
     args: [ "while true; do sleep 300000; done;" ]
     resources:
       requests:
-        intel.com/sriov: '1' 
+        netdev/sriov: '1'
       limits:
-        intel.com/sriov: '1'
+        netdev/sriov: '1'

--- a/deployments/pod-tc2.yaml
+++ b/deployments/pod-tc2.yaml
@@ -15,6 +15,6 @@ spec:
     args: [ "while true; do sleep 300000; done;" ]
     resources:
       requests:
-        intel.com/sriov: '1' 
+        netdev/sriov: '1'
       limits:
-        intel.com/sriov: '1'
+        netdev/sriov: '1'

--- a/deployments/pod-tc3.yaml
+++ b/deployments/pod-tc3.yaml
@@ -15,6 +15,6 @@ spec:
     args: [ "while true; do sleep 300000; done;" ]
     resources:
       requests:
-        intel.com/sriov: '1' 
+        netdev/sriov: '1'
       limits:
-        intel.com/sriov: '1'
+        netdev/sriov: '1'

--- a/deployments/sriov-crd.yaml
+++ b/deployments/sriov-crd.yaml
@@ -3,7 +3,7 @@ kind: NetworkAttachmentDefinition
 metadata:
   name: sriov-net1
   annotations:
-    k8s.v1.cni.cncf.io/resourceName: intel.com/sriov
+    k8s.v1.cni.cncf.io/resourceName: netdev/sriov
 spec:
   config: '{
 	"type": "sriov",


### PR DESCRIPTION
- add command line parameter ``nic-model``
-- ``nic-model`` parameter can be added multiple times to enable different NIC models
-- ``nic-model`` parameter is in the format of ``<vendorID>-<deviceID>``, e.g. ``0x8086-0x10fb``
- change default ``resourceName`` to ``netdev/sriov``