### PR TITLE
switch to kubelet device plugin watcher mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,38 +113,83 @@ $ kubectl create -f pod-sriovdp.yaml
 ````
 $ kubectl logs sriov-device-plugin
 
-sriov-device-plugin.go:380] SRIOV Network Device Plugin started...
-sriov-device-plugin.go:190] Discovering SRIOV network device[s]
-sriov-device-plugin.go:92] Checking for file /sys/class/net/enp0s31f6/device/sriov_numvfs
-sriov-device-plugin.go:92] Checking for file /sys/class/net/enp14s0/device/sriov_numvfs
-sriov-device-plugin.go:92] Checking for file /sys/class/net/enp5s0f0/device/sriov_numvfs
-sriov-device-plugin.go:92] Checking for file /sys/class/net/enp5s0f1/device/sriov_numvfs
-sriov-device-plugin.go:92] Checking for file /sys/class/net/enp5s0f2/device/sriov_numvfs
-sriov-device-plugin.go:92] Checking for file /sys/class/net/enp5s0f3/device/sriov_numvfs
-sriov-device-plugin.go:92] Checking for file /sys/class/net/enp6s2/device/sriov_numvfs
-sriov-device-plugin.go:92] Checking for file /sys/class/net/enp6s2f1/device/sriov_numvfs
-sriov-device-plugin.go:121] Sriov Capable Path: /sys/class/net/enp5s0f0/device/sriov_totalvfs
-sriov-device-plugin.go:133] Total number of VFs for device enp5s0f0 is 32
-sriov-device-plugin.go:135] SRIOV capable device discovered: enp5s0f0
-sriov-device-plugin.go:148] Number of Configured VFs for device enp5s0f0 is 2
-sriov-device-plugin.go:171] PCI Address for device enp5s0f0, VF 0 is 0000:06:02.0
-sriov-device-plugin.go:171] PCI Address for device enp5s0f0, VF 1 is 0000:06:02.1
-sriov-device-plugin.go:121] Sriov Capable Path: /sys/class/net/enp5s0f1/device/sriov_totalvfs
-sriov-device-plugin.go:133] Total number of VFs for device enp5s0f1 is 32
-sriov-device-plugin.go:135] SRIOV capable device discovered: enp5s0f1
-sriov-device-plugin.go:148] Number of Configured VFs for device enp5s0f1 is 0
-sriov-device-plugin.go:121] Sriov Capable Path: /sys/class/net/enp5s0f2/device/sriov_totalvfs
-sriov-device-plugin.go:133] Total number of VFs for device enp5s0f2 is 32
-sriov-device-plugin.go:135] SRIOV capable device discovered: enp5s0f2
-sriov-device-plugin.go:148] Number of Configured VFs for device enp5s0f2 is 0
-sriov-device-plugin.go:121] Sriov Capable Path: /sys/class/net/enp5s0f3/device/sriov_totalvfs
-sriov-device-plugin.go:133] Total number of VFs for device enp5s0f3 is 32
-sriov-device-plugin.go:135] SRIOV capable device discovered: enp5s0f3
-sriov-device-plugin.go:148] Number of Configured VFs for device enp5s0f3 is 0
-sriov-device-plugin.go:195] Starting SRIOV Network Device Plugin server at: /var/lib/kubelet/device-plugins/sriovNet.sock
-sriov-device-plugin.go:220] SRIOV Network Device Plugin server started serving
-sriov-device-plugin.go:402] SRIOV Network Device Plugin registered with the Kubelet
-sriov-device-plugin.go:291] ListAndWatch: send devices &ListAndWatchResponse{Devices:[&Device{ID:0000:06:02.0,Health:Healthy,} &Device{ID:0000:06:02.1,Health:Healthy,}],}
+I0323 05:49:12.547174  324440 sriov-device-plugin.go:469] Starting SRIOV Network Device Plugin...
+I0323 05:49:12.550968  324440 sriov-device-plugin.go:106] Checking inside dir /sys/class/net/cni0
+I0323 05:49:12.551082  324440 sriov-device-plugin.go:117] Checking for file /sys/class/net/cni0/device/sriov_numvfs
+I0323 05:49:12.551159  324440 sriov-device-plugin.go:106] Checking inside dir /sys/class/net/docker0
+I0323 05:49:12.551224  324440 sriov-device-plugin.go:117] Checking for file /sys/class/net/docker0/device/sriov_numvfs
+I0323 05:49:12.551328  324440 sriov-device-plugin.go:106] Checking inside dir /sys/class/net/eno1
+I0323 05:49:12.551445  324440 sriov-device-plugin.go:117] Checking for file /sys/class/net/eno1/device/sriov_numvfs
+I0323 05:49:12.551846  324440 sriov-device-plugin.go:106] Checking inside dir /sys/class/net/eno2
+I0323 05:49:12.551922  324440 sriov-device-plugin.go:117] Checking for file /sys/class/net/eno2/device/sriov_numvfs
+I0323 05:49:12.551999  324440 sriov-device-plugin.go:106] Checking inside dir /sys/class/net/enp135s0f0
+I0323 05:49:12.552074  324440 sriov-device-plugin.go:117] Checking for file /sys/class/net/enp135s0f0/device/sriov_numvfs
+I0323 05:49:12.552152  324440 sriov-device-plugin.go:106] Checking inside dir /sys/class/net/enp135s0f1
+I0323 05:49:12.552225  324440 sriov-device-plugin.go:117] Checking for file /sys/class/net/enp135s0f1/device/sriov_numvfs
+I0323 05:49:12.552306  324440 sriov-device-plugin.go:106] Checking inside dir /sys/class/net/enp135s2
+I0323 05:49:12.552382  324440 sriov-device-plugin.go:117] Checking for file /sys/class/net/enp135s2/device/sriov_numvfs
+I0323 05:49:12.552463  324440 sriov-device-plugin.go:106] Checking inside dir /sys/class/net/enp135s2f1
+I0323 05:49:12.552538  324440 sriov-device-plugin.go:117] Checking for file /sys/class/net/enp135s2f1/device/sriov_numvfs
+I0323 05:49:12.552623  324440 sriov-device-plugin.go:106] Checking inside dir /sys/class/net/enp135s2f2
+I0323 05:49:12.552698  324440 sriov-device-plugin.go:117] Checking for file /sys/class/net/enp135s2f2/device/sriov_numvfs
+I0323 05:49:12.552777  324440 sriov-device-plugin.go:106] Checking inside dir /sys/class/net/enp135s2f3
+I0323 05:49:12.552852  324440 sriov-device-plugin.go:117] Checking for file /sys/class/net/enp135s2f3/device/sriov_numvfs
+I0323 05:49:12.552930  324440 sriov-device-plugin.go:106] Checking inside dir /sys/class/net/enp135s2f4
+I0323 05:49:12.553010  324440 sriov-device-plugin.go:117] Checking for file /sys/class/net/enp135s2f4/device/sriov_numvfs
+I0323 05:49:12.553090  324440 sriov-device-plugin.go:106] Checking inside dir /sys/class/net/enp135s2f5
+I0323 05:49:12.553165  324440 sriov-device-plugin.go:117] Checking for file /sys/class/net/enp135s2f5/device/sriov_numvfs
+I0323 05:49:12.553243  324440 sriov-device-plugin.go:106] Checking inside dir /sys/class/net/enp175s0f0
+I0323 05:49:12.553321  324440 sriov-device-plugin.go:117] Checking for file /sys/class/net/enp175s0f0/device/sriov_numvfs
+I0323 05:49:12.553403  324440 sriov-device-plugin.go:106] Checking inside dir /sys/class/net/enp175s0f1
+I0323 05:49:12.553478  324440 sriov-device-plugin.go:117] Checking for file /sys/class/net/enp175s0f1/device/sriov_numvfs
+I0323 05:49:12.553556  324440 sriov-device-plugin.go:106] Checking inside dir /sys/class/net/enp177s0f0
+I0323 05:49:12.553635  324440 sriov-device-plugin.go:117] Checking for file /sys/class/net/enp177s0f0/device/sriov_numvfs
+I0323 05:49:12.553714  324440 sriov-device-plugin.go:106] Checking inside dir /sys/class/net/enp177s0f1
+I0323 05:49:12.553791  324440 sriov-device-plugin.go:117] Checking for file /sys/class/net/enp177s0f1/device/sriov_numvfs
+I0323 05:49:12.553870  324440 sriov-device-plugin.go:106] Checking inside dir /sys/class/net/lo
+I0323 05:49:12.553942  324440 sriov-device-plugin.go:117] Checking for file /sys/class/net/lo/device/sriov_numvfs
+I0323 05:49:12.554015  324440 sriov-device-plugin.go:106] Checking inside dir /sys/class/net/veth389adcb
+I0323 05:49:12.554087  324440 sriov-device-plugin.go:117] Checking for file /sys/class/net/veth389adcb/device/sriov_numvfs
+I0323 05:49:12.554159  324440 sriov-device-plugin.go:106] Checking inside dir /sys/class/net/vethb391bc4b
+I0323 05:49:12.554231  324440 sriov-device-plugin.go:117] Checking for file /sys/class/net/vethb391bc4b/device/sriov_numvfs
+I0323 05:49:12.554307  324440 sriov-device-plugin.go:209] Discovering all capable and configured devices
+I0323 05:49:12.554340  324440 sriov-device-plugin.go:218] Sriov Capable Path: /sys/class/net/eno1/device/sriov_totalvfs
+I0323 05:49:12.554489  324440 sriov-device-plugin.go:230] Total number of VFs for device eno1 is 32
+I0323 05:49:12.554523  324440 sriov-device-plugin.go:232] SRIOV capable device discovered: eno1
+I0323 05:49:12.554641  324440 sriov-device-plugin.go:245] Number of Configured VFs for device eno1 is 0
+I0323 05:49:12.554675  324440 sriov-device-plugin.go:218] Sriov Capable Path: /sys/class/net/eno2/device/sriov_totalvfs
+I0323 05:49:12.554780  324440 sriov-device-plugin.go:230] Total number of VFs for device eno2 is 32
+I0323 05:49:12.554812  324440 sriov-device-plugin.go:232] SRIOV capable device discovered: eno2
+I0323 05:49:12.554916  324440 sriov-device-plugin.go:245] Number of Configured VFs for device eno2 is 0
+I0323 05:49:12.554944  324440 sriov-device-plugin.go:218] Sriov Capable Path: /sys/class/net/enp135s0f0/device/sriov_totalvfs
+I0323 05:49:12.555044  324440 sriov-device-plugin.go:230] Total number of VFs for device enp135s0f0 is 64
+I0323 05:49:12.555075  324440 sriov-device-plugin.go:232] SRIOV capable device discovered: enp135s0f0
+I0323 05:49:12.555204  324440 sriov-device-plugin.go:245] Number of Configured VFs for device enp135s0f0 is 6
+I0323 05:49:12.557289  324440 sriov-device-plugin.go:218] Sriov Capable Path: /sys/class/net/enp135s0f1/device/sriov_totalvfs
+I0323 05:49:12.557439  324440 sriov-device-plugin.go:230] Total number of VFs for device enp135s0f1 is 64
+I0323 05:49:12.557485  324440 sriov-device-plugin.go:232] SRIOV capable device discovered: enp135s0f1
+I0323 05:49:12.557645  324440 sriov-device-plugin.go:245] Number of Configured VFs for device enp135s0f1 is 0
+I0323 05:49:12.557690  324440 sriov-device-plugin.go:218] Sriov Capable Path: /sys/class/net/enp175s0f0/device/sriov_totalvfs
+I0323 05:49:12.557819  324440 sriov-device-plugin.go:230] Total number of VFs for device enp175s0f0 is 8
+I0323 05:49:12.557861  324440 sriov-device-plugin.go:232] SRIOV capable device discovered: enp175s0f0
+I0323 05:49:12.558021  324440 sriov-device-plugin.go:245] Number of Configured VFs for device enp175s0f0 is 0
+I0323 05:49:12.558075  324440 sriov-device-plugin.go:218] Sriov Capable Path: /sys/class/net/enp175s0f1/device/sriov_totalvfs
+I0323 05:49:12.558230  324440 sriov-device-plugin.go:230] Total number of VFs for device enp175s0f1 is 8
+I0323 05:49:12.558276  324440 sriov-device-plugin.go:232] SRIOV capable device discovered: enp175s0f1
+I0323 05:49:12.558421  324440 sriov-device-plugin.go:245] Number of Configured VFs for device enp175s0f1 is 0
+I0323 05:49:12.558470  324440 sriov-device-plugin.go:218] Sriov Capable Path: /sys/class/net/enp177s0f0/device/sriov_totalvfs
+I0323 05:49:12.558635  324440 sriov-device-plugin.go:230] Total number of VFs for device enp177s0f0 is 6
+I0323 05:49:12.558680  324440 sriov-device-plugin.go:232] SRIOV capable device discovered: enp177s0f0
+I0323 05:49:12.558821  324440 sriov-device-plugin.go:245] Number of Configured VFs for device enp177s0f0 is 0
+I0323 05:49:12.558861  324440 sriov-device-plugin.go:218] Sriov Capable Path: /sys/class/net/enp177s0f1/device/sriov_totalvfs
+I0323 05:49:12.558978  324440 sriov-device-plugin.go:230] Total number of VFs for device enp177s0f1 is 6
+I0323 05:49:12.559007  324440 sriov-device-plugin.go:232] SRIOV capable device discovered: enp177s0f1
+I0323 05:49:12.559092  324440 sriov-device-plugin.go:245] Number of Configured VFs for device enp177s0f1 is 0
+I0323 05:49:12.559119  324440 sriov-device-plugin.go:262] Discovered SR-IOV PF devices: [enp135s0f0]
+I0323 05:49:12.559166  324440 sriov-device-plugin.go:308] Starting SRIOV Network Device Plugin server at: /var/lib/kubelet/plugins_registry/sriovNet.sock
+I0323 05:49:12.560940  324440 sriov-device-plugin.go:333] SRIOV Network Device Plugin server started serving
+I0323 05:49:12.563297  324440 sriov-device-plugin.go:370] Plugin: sriovNet.sock gets registered successfully at Kubelet
+I0323 05:49:12.563499  324440 sriov-device-plugin.go:385] ListAndWatch: send initial devices &ListAndWatchResponse{Devices:[&Device{ID:0000:87:02.3,Health:Healthy,} &Device{ID:0000:87:02.4,Health:Healthy,} &Device{ID:0000:87:02.5,Health:Healthy,} &Device{ID:0000:87:02.0,Health:Healthy,} &Device{ID:0000:87:02.1,Health:Healthy,} &Device{ID:0000:87:02.2,Health:Healthy,}],}
 ````
 
 ### Testing SRIOV workloads

--- a/cmd/sriovdp/sriov-device-plugin.go
+++ b/cmd/sriovdp/sriov-device-plugin.go
@@ -33,7 +33,7 @@ import (
 	"google.golang.org/grpc"
 
 	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
-	registerapi "k8s.io/kubernetes/pkg/kubelet/apis/pluginregistration/v1beta1"
+	registerapi "k8s.io/kubernetes/pkg/kubelet/apis/pluginregistration/v1"
 )
 
 const (
@@ -42,7 +42,7 @@ const (
 	sriovConfigured = "/sriov_numvfs"
 
 	// Device plugin settings.
-	pluginMountPath      = "/var/lib/kubelet/plugins"
+	pluginMountPath      = "/var/lib/kubelet/plugins_registry"
 	pluginEndpointPrefix = "sriovNet"
 	resourceName         = "netdev/sriov"
 )

--- a/cmd/sriovdp/sriovdp_test.go
+++ b/cmd/sriovdp/sriovdp_test.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
-	registerapi "k8s.io/kubernetes/pkg/kubelet/apis/pluginregistration/v1beta1"
+	registerapi "k8s.io/kubernetes/pkg/kubelet/apis/pluginregistration/v1"
 )
 
 func TestSriovdp(t *testing.T) {

--- a/deployments/pod-sriovdp.yaml
+++ b/deployments/pod-sriovdp.yaml
@@ -10,7 +10,7 @@ spec:
     command: [ "/bin/bash", "-c", "--" ]
     args: [ "sriovdp --logtostderr 10;" ]
     volumeMounts:
-    - mountPath: /var/lib/kubelet/device-plugins/ 
+    - mountPath: /var/lib/kubelet/plugins_registry/
       name: devicesock 
       readOnly: false
     - mountPath: /sys/class/net
@@ -20,7 +20,7 @@ spec:
   - name: devicesock 
     hostPath:
      # directory location on host
-     path: /var/lib/kubelet/device-plugins/
+     path: /var/lib/kubelet/plugins_registry/
   - name: net
     hostPath:
       path: /sys/class/net

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 0784e816d6f5215b38bf808e67dd475265c849fad443d8e1094c92831d8c8578
-updated: 2019-03-07T02:40:48.746330417-05:00
+updated: 2019-03-08T04:52:12.61998557-05:00
 imports:
 - name: github.com/gogo/protobuf
   version: c5a62797aee0054613cc578653a16c6237fef080
@@ -99,6 +99,7 @@ imports:
   version: 6dbe98980f97d966cb940cffb3e371b9e43da400
   subpackages:
   - pkg/kubelet/apis/deviceplugin/v1beta1
+  - pkg/kubelet/apis/pluginregistration/v1beta1
 testImports:
 - name: github.com/hpcloud/tail
   version: a1dbeea552b7c8df4b542c66073e393de198a800

--- a/images/README.md
+++ b/images/README.md
@@ -28,7 +28,7 @@ Note: The likely best practice here is to build your own image given the Dockerf
 Example docker run command:
 
 ```
-$ docker run -it -v /var/lib/kubelet/device-plugins/:/var/lib/kubelet/device-plugins/ -v /sys/class/net:/sys/class/net --entrypoint=/bin/bash nfvpe/sriovdp
+$ docker run -it -v /var/lib/kubelet/plugins_registry/:/var/lib/kubelet/plugins_registry/ -v /sys/class/net:/sys/class/net --entrypoint=/bin/bash nfvpe/sriovdp
 ```
 
 Originally inspired by and is a portmanteau of the [Flannel daemonset](https://github.com/coreos/flannel/blob/master/Documentation/kube-flannel.yml), the [Calico Daemonset](https://github.com/projectcalico/calico/blob/master/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend-addon-manager/calico-daemonset.yaml), and the [Calico CNI install bash script](https://github.com/projectcalico/cni-plugin/blob/be4df4db2e47aa7378b1bdf6933724bac1f348d0/k8s-install/scripts/install-cni.sh#L104-L153).

--- a/images/sriovdp-daemonset.yaml
+++ b/images/sriovdp-daemonset.yaml
@@ -46,7 +46,7 @@ spec:
           privileged: false
         volumeMounts:
         - name: devicesock
-          mountPath: /var/lib/kubelet/device-plugins/
+          mountPath: /var/lib/kubelet/plugins_registry/
           readOnly: false
         - name: net
           mountPath: /sys/class/net
@@ -54,7 +54,7 @@ spec:
       volumes:
         - name: devicesock
           hostPath:
-            path: /var/lib/kubelet/device-plugins/
+            path: /var/lib/kubelet/plugins_registry/
         - name: net
           hostPath:
             path: /sys/class/net


### PR DESCRIPTION
KubeletPluginWatcher is enabled by default in kube-1.12.0;
This commit switches registration of Device Plugin to watcher
mode instead of explicitly calling Register in Device Plugin.
This also means Device Plugin will only work with
KubeletPluginWatcher featureGate enabled.