### PR TITLE
travis: remove glide install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: go
 
 before_install:
   - sudo apt-get update -qq
-  # Install Glide
-  - mkdir -p "${GOPATH}/bin"
-  - curl https://glide.sh/get | bash
 
 script:
   - make test


### PR DESCRIPTION
glide is not required when building binary or image,
all the vendor packages should already be updated
properly for a successful build; otherwise we need
to explicitly update the vendor dependencies with
'make vendor' and send a PR.