### PR TITLE
Add pci.ids.gz file to image to avoid downloading it at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apk add --update --virtual build-dependencies build-base linux-headers && \
     make build
 
 FROM alpine
+ADD https://pci-ids.ucw.cz/v2.2/pci.ids.gz /usr/share/misc/pci.ids/
 COPY --from=builder /usr/src/sriov-network-device-plugin/build/sriovdp /usr/bin/
 WORKDIR /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --update --virtual build-dependencies build-base linux-headers && \
     make build
 
 FROM alpine
-ADD https://pci-ids.ucw.cz/v2.2/pci.ids.gz /usr/share/misc/pci.ids/
+RUN apk add hwdata-pci
 COPY --from=builder /usr/src/sriov-network-device-plugin/build/sriovdp /usr/bin/
 WORKDIR /
 


### PR DESCRIPTION
 `ghw.PCI()` trys to download pci.ids.gz form Internet if it cannot be found locally. We should not assume the container always has Internet access available. 

Event when the container has Internet access, due to there is no ca certificates installed, the following error pops up.
"error discovering host network devicesdiscoverDevices(): error getting PCI info: Get https://pci-ids.ucw.cz/v2.2/pci.ids.gz: x509: certificate signed by unknown authority"