### PR TITLE
remove host mount for /usr/share/hwdata

### DIFF
--- a/deployments/pod-sriovdp.yaml
+++ b/deployments/pod-sriovdp.yaml
@@ -21,9 +21,6 @@ spec:
     - mountPath: /etc/pcidp/
       name: config
       readOnly: true
-    - name: hwdata
-      mountPath: /usr/share/hwdata
-      readOnly: true
     - name: config-volume
       mountPath: /etc/pcidp
   volumes:
@@ -36,9 +33,6 @@ spec:
   - name: config
     hostPath:
       path: /etc/pcidp/
-  - name: hwdata
-    hostPath:
-      path: /usr/share/hwdata
   - name: config-volume
     configMap:
       name: sriovdp-config

--- a/images/sriovdp-daemonset.yaml
+++ b/images/sriovdp-daemonset.yaml
@@ -45,9 +45,6 @@ spec:
           readOnly: false
         - name: log
           mountPath: /var/log
-        - name: hwdata
-          mountPath: /usr/share/hwdata
-          readOnly: true
         - name: config-volume
           mountPath: /etc/pcidp
       volumes:
@@ -57,9 +54,6 @@ spec:
         - name: log
           hostPath:
             path: /var/log
-        - name: hwdata
-          hostPath:
-            path: /usr/share/hwdata
         - name: config-volume
           configMap:
             name: sriovdp-config


### PR DESCRIPTION
Since the hwdata package is being installed in docker image to
avoid downloading the pci.ids at runtime, the host mount is no
longer needed.
