### PR TITLE
fix: igb_uio export device specs

### DIFF
--- a/pkg/resources/factory.go
+++ b/pkg/resources/factory.go
@@ -56,7 +56,7 @@ func (rf *resourceFactory) GetInfoProvider(name string) types.DeviceInfoProvider
 	switch name {
 	case "vfio-pci":
 		return newVfioResourcePool()
-	case "uio":
+	case "uio", "igb_uio":
 		return newUioResourcePool()
 	default:
 		return newNetDevicePool()


### PR DESCRIPTION
This patch fixes an issue where selecting igb_uio drivers did not
provide required device specs to container runtime.

Change-Id: I9c1e33bbb77bfc0a7e7af66fa351eafa5e067d90