### PR TITLE
Filtering devices of interfaces that do not belong namespace

### DIFF
--- a/cmd/sriovdp/manager.go
+++ b/cmd/sriovdp/manager.go
@@ -207,9 +207,11 @@ func (rm *resourceManager) discoverHostDevices() error {
 				productName = string([]byte(productName)[0:37]) + "..."
 			}
 			glog.Infof("discoverDevices(): device found: %-12s\t%-12s\t%-20s\t%-40s", device.Address, device.Class.ID, vendorName, productName)
+			isUsed, _ := isInUse(device.Address)
+			belongsToNamespace, _ := utils.BelongsToNamespace(device.Address)
 
 			// exclude device in-use in host
-			if isUsed, _ := isInUse(device.Address); !isUsed {
+			if !isUsed && belongsToNamespace {
 
 				aPF := utils.IsSriovPF(device.Address)
 				aVF := utils.IsSriovVF(device.Address)

--- a/cmd/sriovdp/manager_test.go
+++ b/cmd/sriovdp/manager_test.go
@@ -382,6 +382,12 @@ var _ = Describe("Resource manager", func() {
 				},
 			},
 		),
+		Entry("PF device with VF configured, not belonging to current ns",
+			&utils.FakeFilesystem{
+				Dirs:     []string{"/sys/bus/pci/devices/0000:01:00.0/net/", "sys/bus/pci/devices/0000:01:10.0"},
+				Symlinks: map[string]string{"sys/bus/pci/devices/0000:01:10.0/physfn": "../0000:01:00.0"},
+			},
+		),
 	)
 	DescribeTable("adding to link watch list",
 		func(fs *utils.FakeFilesystem, addr string, expected []types.LinkWatcher) {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -74,6 +74,25 @@ func GetPfName(pciAddr string) (string, error) {
 	return files[0].Name(), nil
 }
 
+// BelongsToNamespace checks if the PCI network device link belongs to the current namespace.
+func BelongsToNamespace(pciAddr string) (bool, error) {
+	path := ""
+	if !IsSriovVF(pciAddr) {
+		path = filepath.Join(sysBusPci, pciAddr, "net")
+	} else {
+		path = filepath.Join(sysBusPci, pciAddr, "physfn/net")
+	}
+
+	files, err := ioutil.ReadDir(path)
+	if err != nil {
+		return false, err
+	}
+	if len(files) == 0 { // devices that do not belong to the current namespace do not have the name under /net
+		return false, nil
+	}
+	return true, nil
+}
+
 // IsSriovPF check if a pci device SRIOV capable given its pci address
 func IsSriovPF(pciAddr string) bool {
 	totalVfFilePath := filepath.Join(sysBusPci, pciAddr, totalVfFile)


### PR DESCRIPTION
With docker in docker setup, what happens is we have the device listed under /sys/bus/pci/devices/ but the /net link is empty and it does not contain the interface name. This makes the plugin to crash (as described in https://github.com/intel/sriov-network-device-plugin/issues/141). 

With this PR, we filter out eventual host devices that are not listed in the current network namespace.