### PR TITLE
fix a runtime error if PF interface name not found

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -65,13 +65,20 @@ func GetPfName(pciAddr string) (string, error) {
 		if os.IsNotExist(err) {
 			path := filepath.Join(sysBusPci, pciAddr, "net")
 			files, err = ioutil.ReadDir(path)
-			if err == nil {
-				return files[0].Name(), nil
+			if err != nil {
+				return "", err
 			}
+			if len(files) < 1 {
+				return "", fmt.Errorf("no interface name found for device %s", pciAddr)
+			}
+			return files[0].Name(), nil
 		}
 		return "", err
+	} else if len(files) > 0 {
+		return files[0].Name(), nil
 	}
-	return files[0].Name(), nil
+	return "", fmt.Errorf("no interface name found for device %s", pciAddr)
+
 }
 
 // IsSriovPF check if a pci device SRIOV capable given its pci address


### PR DESCRIPTION
The GetPFName() is used to determine a device's PF name if it was
an SR-IOV VF. For non SR-IOV devices, it would try to get device's
corresponding kernel net interface name. This name is unavailable
if the interface is not in the same namespace(see #141) or the
device is enabled for dpdk mode.
In those cases this function should return appropriate errors to
the caller if no interface name is found.

Change-Id: Id7c6662a2a86f20eb91fcfc4d4f965cd31f9d9b0