### PR TITLE
Add Link Type selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ This plugin creates device plugin endpoints based on the configurations given in
 |     Field      | Required |        Description        |                      Type - Accepted values                       |                                      Example/Accepted values                                       |
 |----------------|----------|---------------------------|-------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
 | "resourceName" | Yes      | Endpoint resource name    | string - must be unique and should not contain special characters | "sriov_net_A"                                                                                      |
-| "selectors"    | No       | A map of device selectors | Each selector is a map of string list.                            | "vendors": ["8086"], "devices": ["154c", "10ed"], "drivers": ["vfio-pci"], "pfNames": ["enp2s2f0"] |
+| "selectors"    | No       | A map of device selectors | Each selector is a map of string list.                            | "vendors": ["8086"], "devices": ["154c", "10ed"], "drivers": ["vfio-pci"], "pfNames": ["enp2s2f0"], "linkTypes": ["ether"] |
 | "isRdma"       | No       | Mount RDMA resources      | `bool` - boolean value true or false                              | "isRdma": true                                                                                     |
 
 
@@ -230,6 +230,7 @@ The device plugin will initially discover all PCI network resources in the host 
 2. "devices" - The device hex code of device
 3. "drivers" - The driver name the device is registered with
 4. "pfNames" - The Physical funtion name
+5. "linkTypes" - The link type of the net device associated with the PCI device.
 
 ### Workflow
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,13 @@ This plugin creates device plugin endpoints based on the configurations given in
                 "devices": ["1018"],
                 "drivers": ["mlx5_ib"]
             }
+        },
+        {
+            "resourceName": "infiniband_rdma_netdevs",
+            "isRdma": true,
+            "selectors": {
+                "linkTypes": ["infiniband"]
+            }
         }
     ]
 }

--- a/pkg/resources/deviceSelectors.go
+++ b/pkg/resources/deviceSelectors.go
@@ -84,6 +84,25 @@ func (s *pfNameSelector) Filter(inDevices []types.PciNetDevice) []types.PciNetDe
 	return filteredList
 }
 
+// newLinkTypeSelector returns a interface for netDev list
+func newLinkTypeSelector(linkTypes []string) types.DeviceSelector {
+	return &linkTypeSelector{linkTypes: linkTypes}
+}
+
+type linkTypeSelector struct {
+	linkTypes []string
+}
+
+func (s *linkTypeSelector) Filter(inDevices []types.PciNetDevice) []types.PciNetDevice {
+	filteredList := make([]types.PciNetDevice, 0)
+	for _, dev := range inDevices {
+		if contains(s.linkTypes, dev.GetLinkType()) {
+			filteredList = append(filteredList, dev)
+		}
+	}
+	return filteredList
+}
+
 func contains(hay []string, needle string) bool {
 	for _, s := range hay {
 		if s == needle {

--- a/pkg/resources/deviceSelectors_test.go
+++ b/pkg/resources/deviceSelectors_test.go
@@ -113,4 +113,31 @@ var _ = Describe("DeviceSelectors", func() {
 			})
 		})
 	})
+
+	Describe("linkType selector", func() {
+		Context("initializing", func() {
+			It("should populate linkTypes array", func() {
+				linkTypes := []string{"ether"}
+				sel := newLinkTypeSelector(linkTypes).(*linkTypeSelector)
+				Expect(sel.linkTypes).To(ConsistOf(linkTypes))
+			})
+		})
+		Context("filtering", func() {
+			It("should return devices matching the correct link type", func() {
+				linkTypes := []string{"ether"}
+				sel := newLinkTypeSelector(linkTypes).(*linkTypeSelector)
+
+				dev0 := mocks.PciNetDevice{}
+				dev0.On("GetLinkType").Return("ether")
+				dev1 := mocks.PciNetDevice{}
+				dev1.On("GetLinkType").Return("infiniband")
+
+				in := []types.PciNetDevice{&dev0, &dev1}
+				filtered := sel.Filter(in)
+
+				Expect(filtered).To(ContainElement(&dev0))
+				Expect(filtered).NotTo(ContainElement(&dev1))
+			})
+		})
+	})
 })

--- a/pkg/resources/factory.go
+++ b/pkg/resources/factory.go
@@ -75,6 +75,8 @@ func (rf *resourceFactory) GetSelector(attr string, values []string) (types.Devi
 		return newDriverSelector(values), nil
 	case "pfNames":
 		return newPfNameSelector(values), nil
+	case "linkTypes":
+		return newLinkTypeSelector(values), nil
 	default:
 		return nil, fmt.Errorf("GetSelector(): invalid attribute %s", attr)
 	}
@@ -108,6 +110,16 @@ func (rf *resourceFactory) GetResourcePool(rc *types.ResourceConfig, deviceList 
 	// filter by PfNames list
 	if rc.Selectors.PfNames != nil && len(rc.Selectors.PfNames) > 0 {
 		if selector, err := rf.GetSelector("pfNames", rc.Selectors.PfNames); err == nil {
+			filteredDevice = selector.Filter(filteredDevice)
+		}
+	}
+
+	// filter by linkTypes list
+	if rc.Selectors.LinkTypes != nil && len(rc.Selectors.LinkTypes) > 0 {
+		if len(rc.Selectors.LinkTypes) > 1 {
+			glog.Warningf("Link type selector should have a single value.")
+		}
+		if selector, err := rf.GetSelector("linkTypes", rc.Selectors.LinkTypes); err == nil {
 			filteredDevice = selector.Filter(filteredDevice)
 		}
 	}

--- a/pkg/resources/pciNetDevice.go
+++ b/pkg/resources/pciNetDevice.go
@@ -23,6 +23,7 @@ type pciNetDevice struct {
 	deviceSpecs []*pluginapi.DeviceSpec
 	mounts      []*pluginapi.Mount
 	rdmaSpec    types.RdmaSpec
+	linkType    string
 }
 
 // NewPciNetDevice returns an instance of PciNetDevice interface
@@ -60,6 +61,15 @@ func NewPciNetDevice(pciDevice *ghw.PCIDevice, rFactory types.ResourceFactory) (
 		Health: pluginapi.Healthy,
 	}
 
+	linkType := ""
+	if len(ifName) > 0 {
+		la, err := utils.GetLinkAttrs(ifName)
+		if err != nil {
+			return nil, err
+		}
+		linkType = la.EncapType
+	}
+
 	// 			4. Create pciNetDevice object with all relevent info
 	return &pciNetDevice{
 		pciDevice:   pciDevice,
@@ -74,6 +84,7 @@ func NewPciNetDevice(pciDevice *ghw.PCIDevice, rFactory types.ResourceFactory) (
 		env:         env,
 		numa:        "", // TO-DO: Get this using utils pkg
 		rdmaSpec:    rdmaSpec,
+		linkType:    linkType,
 	}, nil
 }
 
@@ -139,4 +150,8 @@ func (nd *pciNetDevice) GetRdmaSpec() types.RdmaSpec {
 
 func getPFInfos(pciAddr string) (pfAddr, pfName string, err error) {
 	return "", "", nil
+}
+
+func (nd *pciNetDevice) GetLinkType() string {
+	return nd.linkType
 }

--- a/pkg/resources/pciNetDevice_test.go
+++ b/pkg/resources/pciNetDevice_test.go
@@ -25,6 +25,7 @@ var _ = Describe("PciNetDevice", func() {
 					},
 				}
 				defer fs.Use()()
+				defer utils.UseFakeLinks()()
 
 				f := NewResourceFactory("fake", "fake", true)
 				in := &ghw.PCIDevice{Address: "0000:00:00.1"}
@@ -38,6 +39,7 @@ var _ = Describe("PciNetDevice", func() {
 				Expect(out.deviceSpecs).To(HaveLen(2)) // /dev/vfio/vfio0 and default /dev/vfio/vfio
 				Expect(out.GetRdmaSpec().IsRdma()).To(BeFalse())
 				Expect(out.GetRdmaSpec().GetRdmaDeviceSpec()).To(HaveLen(0))
+				Expect(out.GetLinkType()).To(Equal("fakeLinkType"))
 
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -49,6 +51,7 @@ var _ = Describe("PciNetDevice", func() {
 					Files: map[string][]byte{"sys/bus/pci/devices/0000:00:00.1/driver": []byte("not a symlink")},
 				}
 				defer fs.Use()()
+				defer utils.UseFakeLinks()()
 
 				f := NewResourceFactory("fake", "fake", true)
 				in := &ghw.PCIDevice{

--- a/pkg/resources/pool_stub_test.go
+++ b/pkg/resources/pool_stub_test.go
@@ -45,6 +45,7 @@ var _ = Describe("PoolStub", func() {
 		Context("for valid devices", func() {
 			It("should return valid DeviceSpec array", func() {
 				defer fs.Use()()
+				defer utils.UseFakeLinks()()
 
 				d1, _ = NewPciNetDevice(&ghw.PCIDevice{Address: "0000:00:00.1"}, f)
 				d2, _ = NewPciNetDevice(&ghw.PCIDevice{Address: "0000:00:00.2"}, f)
@@ -71,6 +72,7 @@ var _ = Describe("PoolStub", func() {
 		Context("for valid devices", func() {
 			It("should return valid envs array", func() {
 				defer fs.Use()()
+				defer utils.UseFakeLinks()()
 
 				d1, _ = NewPciNetDevice(&ghw.PCIDevice{Address: "0000:00:00.1"}, f)
 				d2, _ = NewPciNetDevice(&ghw.PCIDevice{Address: "0000:00:00.2"}, f)
@@ -93,6 +95,7 @@ var _ = Describe("PoolStub", func() {
 		Context("for valid devices", func() {
 			It("should return valid mounts array", func() {
 				defer fs.Use()()
+				defer utils.UseFakeLinks()()
 
 				d1, _ = NewPciNetDevice(&ghw.PCIDevice{Address: "0000:00:00.1"}, f)
 				d2, _ = NewPciNetDevice(&ghw.PCIDevice{Address: "0000:00:00.2"}, f)

--- a/pkg/resources/server_test.go
+++ b/pkg/resources/server_test.go
@@ -127,11 +127,12 @@ var _ = Describe("Server", func() {
 			fakeConf = &types.ResourceConfig{
 				ResourceName: "fake",
 				Selectors: struct {
-					Vendors []string `json:"vendors,omitempty"`
-					Devices []string `json:"devices,omitempty"`
-					Drivers []string `json:"drivers,omitempty"`
-					PfNames []string `json:"pfNames,omitempty"`
-				}{[]string{}, []string{"fakeid"}, []string{}, []string{}},
+					Vendors   []string `json:"vendors,omitempty"`
+					Devices   []string `json:"devices,omitempty"`
+					Drivers   []string `json:"drivers,omitempty"`
+					PfNames   []string `json:"pfNames,omitempty"`
+					LinkTypes []string `json:"linkTypes,omitempty"`
+				}{[]string{}, []string{"fakeid"}, []string{}, []string{}, []string{}},
 			}
 			rp = mocks.ResourcePool{}
 			rp.On("GetConfig").Return(fakeConf).

--- a/pkg/types/mocks/PciNetDevice.go
+++ b/pkg/types/mocks/PciNetDevice.go
@@ -99,6 +99,20 @@ func (_m *PciNetDevice) GetLinkSpeed() string {
 	return r0
 }
 
+// GetLinkType provides a mock function with given fields:
+func (_m *PciNetDevice) GetLinkType() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // GetMounts provides a mock function with given fields:
 func (_m *PciNetDevice) GetMounts() []*v1beta1.Mount {
 	ret := _m.Called()

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -35,10 +35,11 @@ type ResourceConfig struct {
 	ResourceName string `json:"resourceName"` // the resource name will be added with resource prefix in K8s api
 	IsRdma       bool   // the resource support rdma
 	Selectors    struct {
-		Vendors []string `json:"vendors,omitempty"`
-		Devices []string `json:"devices,omitempty"`
-		Drivers []string `json:"drivers,omitempty"`
-		PfNames []string `json:"pfNames,omitempty"`
+		Vendors   []string `json:"vendors,omitempty"`
+		Devices   []string `json:"devices,omitempty"`
+		Drivers   []string `json:"drivers,omitempty"`
+		PfNames   []string `json:"pfNames,omitempty"`
+		LinkTypes []string `json:"linkTypes,omitempty"`
 	} `json:"selectors,omitempty"` // Whether devices have SRIOV virtual function capabilities or not
 }
 
@@ -91,6 +92,7 @@ type PciNetDevice interface {
 	GetNetName() string
 	IsSriovPF() bool
 	GetLinkSpeed() string
+	GetLinkType() string
 	GetSubClass() string
 	GetDeviceSpecs() []*pluginapi.DeviceSpec
 	GetEnvVal() string

--- a/pkg/utils/netlink_provider.go
+++ b/pkg/utils/netlink_provider.go
@@ -1,0 +1,63 @@
+// Copyright 2018 Intel Corp. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+	nl "github.com/vishvananda/netlink"
+)
+
+var (
+	// getLinkByName is a function that retrieves nl.Link object according to
+	// a provided netdev name.
+	getLinkByName = nl.LinkByName
+)
+
+// GetLinkAttrs returns a net device's link attributes.
+func GetLinkAttrs(ifName string) (*nl.LinkAttrs, error) {
+	link, err := getLinkByName(ifName)
+	if err != nil {
+		return nil, fmt.Errorf("error getting link attributes for net device %s %v", ifName, err)
+	}
+	return link.Attrs(), nil
+}
+
+type fakeLink struct {
+	nl.LinkAttrs
+}
+
+func (fl fakeLink) Attrs() *nl.LinkAttrs {
+	return &fl.LinkAttrs
+}
+
+func (fl fakeLink) Type() string {
+	return "fakeType"
+}
+
+// GetFakeLinkByName retrieve a fake nl.Link object
+func getFakeLinkByName(string) (nl.Link, error) {
+	attrs := nl.LinkAttrs{EncapType: "fakeLinkType"}
+	return fakeLink{LinkAttrs: attrs}, nil
+}
+
+// UseFakeLinks causes GetLinkByName to retrieve fake netlink Link object
+// return value intended to be used in unit-tests as deffered method to
+// restore GetLinkByName to be the actual netlink implementation.
+func UseFakeLinks() func() {
+	getLinkByName = getFakeLinkByName
+	return func() {
+		getLinkByName = nl.LinkByName
+	}
+}


### PR DESCRIPTION
Add the ability to filter according to a device's link type.
This will enable a user to filter SR-IOV resources according
to link type, allowing the creation of resource pools based on
the underlying fabric a device is connected to
(e.g ethernet, infiniband).