### PR TITLE
only exclude default route interface

### DIFF
--- a/cmd/sriovdp/manager.go
+++ b/cmd/sriovdp/manager.go
@@ -209,7 +209,7 @@ func (rm *resourceManager) discoverHostDevices() error {
 			glog.Infof("discoverDevices(): device found: %-12s\t%-12s\t%-20s\t%-40s", device.Address, device.Class.ID, vendorName, productName)
 
 			// exclude device in-use in host
-			if isUsed, _ := isInUse(device.Address); !isUsed {
+			if isDefaultRoute, _ := hasDefaultRoute(device.Address); !isDefaultRoute {
 
 				aPF := utils.IsSriovPF(device.Address)
 				aVF := utils.IsSriovVF(device.Address)
@@ -236,9 +236,8 @@ func (rm *resourceManager) discoverHostDevices() error {
 	return nil
 }
 
-// isInUse returns true if PCI network device appear to be in use by host system given its pci address as string.
-// Otherwise it is assumed not to be in used.
-func isInUse(pciAddr string) (bool, error) {
+// hasDefaultRoute returns true if PCI network device is default route interface
+func hasDefaultRoute(pciAddr string) (bool, error) {
 
 	// inUse := false
 	// Get net interface name
@@ -255,9 +254,11 @@ func isInUse(pciAddr string) (bool, error) {
 			}
 
 			routes, err := netlink.RouteList(link, netlink.FAMILY_V4) // IPv6 routes: all interface has at least one link local route entry
-			if len(routes) > 0 {
-				glog.Infof("excluding interface %s:  route entry found: %+v", ifName, routes)
-				return true, nil
+			for _, r := range routes {
+				if r.Dst == nil {
+					glog.Infof("excluding interface %s:  default route found: %+v", ifName, r)
+					return true, nil
+				}
 			}
 		}
 	}

--- a/cmd/sriovdp/manager_test.go
+++ b/cmd/sriovdp/manager_test.go
@@ -273,11 +273,11 @@ var _ = Describe("Resource manager", func() {
 			})
 		})
 	})
-	DescribeTable("checking whether device is in use",
+	DescribeTable("checking whether device has default route",
 		func(fs *utils.FakeFilesystem, addr string, expected, shouldFail bool) {
 			defer fs.Use()()
 
-			actual, err := isInUse(addr)
+			actual, err := hasDefaultRoute(addr)
 			Expect(actual).To(Equal(expected))
 			assertShouldFail(err, shouldFail)
 		},


### PR DESCRIPTION
When PF is connected to a dhcp network, creation of VFs
will result in IP address being assigned to each VF. Current
Device Plugin ignore such devices and doesn't count it as
allocatable devices.

This commit changes such behavior by checking and filtering
out device with default route, leaving other devices as
available resource.