### PR TITLE
allow device to be added without PF info

### DIFF
--- a/pkg/resources/pciNetDevice.go
+++ b/pkg/resources/pciNetDevice.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"github.com/golang/glog"
 	"github.com/intel/sriov-network-device-plugin/pkg/types"
 	"github.com/intel/sriov-network-device-plugin/pkg/utils"
 	"github.com/jaypipes/ghw"
@@ -46,7 +47,7 @@ func NewPciNetDevice(pciDevice *ghw.PCIDevice, rFactory types.ResourceFactory) (
 	}
 	pfName, err := utils.GetPfName(pciAddr)
 	if err != nil {
-		return nil, err
+		glog.Warningf("unable to get PF name %q", err.Error())
 	}
 
 	// 			3. Get Device file info (e.g., uio, vfio specific)

--- a/pkg/resources/pciNetDevice_test.go
+++ b/pkg/resources/pciNetDevice_test.go
@@ -64,5 +64,32 @@ var _ = Describe("PciNetDevice", func() {
 				Expect(err).To(HaveOccurred())
 			})
 		})
+		Context("device's PF name is not available", func() {
+			It("device should be added", func() {
+				fs := &utils.FakeFilesystem{
+					Dirs: []string{"sys/bus/pci/devices/0000:00:00.1"},
+					Symlinks: map[string]string{
+						"sys/bus/pci/devices/0000:00:00.1/iommu_group": "../../../../kernel/iommu_groups/0",
+						"sys/bus/pci/devices/0000:00:00.1/driver":      "../../../../bus/pci/drivers/vfio-pci",
+					},
+				}
+				defer fs.Use()()
+				defer utils.UseFakeLinks()()
+
+				f := NewResourceFactory("fake", "fake", true)
+				in := &ghw.PCIDevice{
+					Address: "0000:00:00.1",
+				}
+
+				dev, err := NewPciNetDevice(in, f)
+				Expect(err).NotTo(HaveOccurred())
+
+				out := dev.(*pciNetDevice)
+
+				Expect(dev).NotTo(BeNil())
+
+				Expect(out.env).To(Equal("0000:00:00.1"))
+			})
+		})
 	})
 })

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -77,7 +77,7 @@ func GetPfName(pciAddr string) (string, error) {
 	} else if len(files) > 0 {
 		return files[0].Name(), nil
 	}
-	return "", fmt.Errorf("no interface name found for device %s", pciAddr)
+	return "", fmt.Errorf("the PF name is not found for device %s", pciAddr)
 
 }
 


### PR DESCRIPTION
There are situation where a VF's PF information is not accessble, for example
in VM pass-through mode. This change will allow device plugin to simply log
such events and allow such devices to be added in the discovered device list.
