### PR TITLE
Add pciAddresses selectors for VM usecase

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,11 +232,12 @@ The "deviceType" value determines which selectors are supported for that device.
 #### Common selectors
 All device types support following common device selectors.
 
-|   Field   | Required |                Description                |         Type/Defaults          |   Example/Accepted values   |
-|-----------|----------|-------------------------------------------|--------------------------------|-----------------------------|
-| "vendors" | N        | Target device's vendor Hex code as string | `string` list Default: `null`  | "vendors": ["8086"]         |
-| "devices" | N        | Target Devices' device Hex code as string | `string` list Default: `null`  | "devices": ["154c", "10ed"] |
-| "drivers" | N        | Target device driver names as string      | `string` list Default: `null`  | "drivers": ["vfio-pci"]     |
+|   Field        | Required |                Description                |         Type/Defaults          |   Example/Accepted values        |
+|----------------|----------|-------------------------------------------|--------------------------------|----------------------------------|
+| "vendors"      | N        | Target device's vendor Hex code as string | `string` list Default: `null`  | "vendors": ["8086"]              |
+| "devices"      | N        | Target Devices' device Hex code as string | `string` list Default: `null`  | "devices": ["154c", "10ed"]      |
+| "drivers"      | N        | Target device driver names as string      | `string` list Default: `null`  | "drivers": ["vfio-pci"]          |
+| "pciAddresses" | N        | Target device's pci address as string     | `string` list Default: `null`  | "pciAddresses": ["0000:03:02.0"] |
 
 
 #### Extended selectors for device type "netDevice"
@@ -296,6 +297,7 @@ The device plugin will initially discover all PCI network resources in the host 
 1. "vendors" - The vendor hex code of device
 2. "devices" - The device hex code of device
 3. "drivers" - The driver name the device is registered with
+4. "pciAddresses" - The pci address of the device in BDF notation
 4. "pfNames" - The Physical function name
 5. "linkTypes" - The link type of the net device associated with the PCI device.
 

--- a/cmd/sriovdp/manager_test.go
+++ b/cmd/sriovdp/manager_test.go
@@ -389,6 +389,28 @@ var _ = Describe("Resource manager", func() {
 				},
 			},
 		),
+		Entry("VF device without PF and bound to dpdk driver",
+			&utils.FakeFilesystem{
+				Dirs: []string{
+					"sys/bus/pci/devices/0000:03:02.0",
+					"sys/bus/pci/devices/0000:03:02.1",
+				},
+				Files: map[string][]byte{
+					"sys/bus/pci/devices/0000:03:02.0/modalias": []byte(
+						"pci:v00008086d0000154Csv00008086sd00000000bc02sc00i00",
+					),
+					"sys/bus/pci/devices/0000:03:02.1/modalias": []byte(
+						"pci:v00008086d0000154Csv00008086sd00000000bc02sc00i00",
+					),
+					"sys/bus/pci/devices/0000:03:02.0/max_vfs": []byte("0"),
+					"sys/bus/pci/devices/0000:03:02.1/max_vfs": []byte("0"),
+				},
+				Symlinks: map[string]string{
+					"sys/bus/pci/devices/0000:03:02.0/driver": "../../../../bus/pci/drivers/igb_uio",
+					"sys/bus/pci/devices/0000:03:02.1/driver": "../../../../bus/pci/drivers/igb_uio",
+				},
+			},
+		),
 	)
 	Describe("starting all server", func() {
 		Context("when resource servers are starting fine", func() {

--- a/pkg/factory/factory.go
+++ b/pkg/factory/factory.go
@@ -83,6 +83,8 @@ func (rf *resourceFactory) GetSelector(attr string, values []string) (types.Devi
 		return resources.NewDriverSelector(values), nil
 	case "pfNames":
 		return resources.NewPfNameSelector(values), nil
+	case "pciAddresses":
+		return resources.NewPciAddressSelector(values), nil
 	case "linkTypes":
 		return resources.NewLinkTypeSelector(values), nil
 	case "ddpProfiles":

--- a/pkg/factory/factory.go
+++ b/pkg/factory/factory.go
@@ -81,10 +81,10 @@ func (rf *resourceFactory) GetSelector(attr string, values []string) (types.Devi
 		return resources.NewDeviceSelector(values), nil
 	case "drivers":
 		return resources.NewDriverSelector(values), nil
-	case "pfNames":
-		return resources.NewPfNameSelector(values), nil
 	case "pciAddresses":
 		return resources.NewPciAddressSelector(values), nil
+	case "pfNames":
+		return resources.NewPfNameSelector(values), nil
 	case "linkTypes":
 		return resources.NewLinkTypeSelector(values), nil
 	case "ddpProfiles":

--- a/pkg/factory/factory_test.go
+++ b/pkg/factory/factory_test.go
@@ -83,8 +83,8 @@ var _ = Describe("Factory", func() {
 		Entry("vendors", "vendors", true, reflect.TypeOf(resources.NewVendorSelector([]string{}))),
 		Entry("devices", "devices", true, reflect.TypeOf(resources.NewDeviceSelector([]string{}))),
 		Entry("drivers", "drivers", true, reflect.TypeOf(resources.NewDriverSelector([]string{}))),
-		Entry("pfNames", "pfNames", true, reflect.TypeOf(resources.NewPfNameSelector([]string{}))),
 		Entry("pciAddresses", "pciAddresses", true, reflect.TypeOf(resources.NewPciAddressSelector([]string{}))),
+		Entry("pfNames", "pfNames", true, reflect.TypeOf(resources.NewPfNameSelector([]string{}))),
 		Entry("linkTypes", "linkTypes", true, reflect.TypeOf(resources.NewLinkTypeSelector([]string{}))),
 		Entry("ddpProfiles", "ddpProfiles", true, reflect.TypeOf(resources.NewDdpSelector([]string{}))),
 		Entry("invalid", "fakeAndInvalid", false, reflect.TypeOf(nil)),
@@ -104,8 +104,8 @@ var _ = Describe("Factory", func() {
 				vendors := []string{"8086", "8086", "8086", "1234"}
 				codes := []string{"1111", "1111", "1234", "4321"}
 				drivers := []string{"vfio-pci", "i40evf", "igb_uio", "igb_uio"}
-				pfNames := []string{"enp2s0f2", "ens0", "eth0", "net2"}
 				pciAddr := []string{"0000:03:02.0", "0000:03:02.1", "0000:03:02.2", "0000:03:02.3"}
+				pfNames := []string{"enp2s0f2", "ens0", "eth0", "net2"}
 				linkTypes := []string{"ether", "infiniband", "other", "other2"}
 				ddpProfiles := []string{"GTP", "PPPoE", "GTP", "PPPoE"}
 				for i := range devs {
@@ -113,8 +113,8 @@ var _ = Describe("Factory", func() {
 					d.On("GetVendor").Return(vendors[i]).
 						On("GetDeviceCode").Return(codes[i]).
 						On("GetDriver").Return(drivers[i]).
-						On("GetPFName").Return(pfNames[i]).
 						On("GetPciAddr").Return(pciAddr[i]).
+						On("GetPFName").Return(pfNames[i]).
 						On("GetAPIDevice").Return(&pluginapi.Device{}).
 						On("GetLinkType").Return(linkTypes[i]).
 						On("GetDDPProfiles").Return(ddpProfiles[i])
@@ -128,8 +128,8 @@ var _ = Describe("Factory", func() {
 							"vendors": ["8086"],
 							"devices": ["1111"],
 							"drivers": ["vfio-pci"],
-							"pfNames": ["enp2s0f2"],
 							"pciAddresses": ["0000:03:02.0"],
+							"pfNames": ["enp2s0f2"],
 							"linkTypes": ["ether"],
 							"ddpProfiles": ["GTP"]
 						}

--- a/pkg/factory/factory_test.go
+++ b/pkg/factory/factory_test.go
@@ -84,6 +84,7 @@ var _ = Describe("Factory", func() {
 		Entry("devices", "devices", true, reflect.TypeOf(resources.NewDeviceSelector([]string{}))),
 		Entry("drivers", "drivers", true, reflect.TypeOf(resources.NewDriverSelector([]string{}))),
 		Entry("pfNames", "pfNames", true, reflect.TypeOf(resources.NewPfNameSelector([]string{}))),
+		Entry("pciAddresses", "pciAddresses", true, reflect.TypeOf(resources.NewPciAddressSelector([]string{}))),
 		Entry("linkTypes", "linkTypes", true, reflect.TypeOf(resources.NewLinkTypeSelector([]string{}))),
 		Entry("ddpProfiles", "ddpProfiles", true, reflect.TypeOf(resources.NewDdpSelector([]string{}))),
 		Entry("invalid", "fakeAndInvalid", false, reflect.TypeOf(nil)),
@@ -128,6 +129,7 @@ var _ = Describe("Factory", func() {
 							"devices": ["1111"],
 							"drivers": ["vfio-pci"],
 							"pfNames": ["enp2s0f2"],
+							"pciAddresses": ["0000:03:02.0"],
 							"linkTypes": ["ether"],
 							"ddpProfiles": ["GTP"]
 						}

--- a/pkg/netdevice/netDeviceProvider.go
+++ b/pkg/netdevice/netDeviceProvider.go
@@ -149,16 +149,16 @@ func (np *netDeviceProvider) GetFilteredDevices(devices []types.PciDevice, rc *t
 		}
 	}
 
-	// filter by PfNames list
-	if nf.PfNames != nil && len(nf.PfNames) > 0 {
-		if selector, err := rf.GetSelector("pfNames", nf.PfNames); err == nil {
+	// filter by pciAddresses list
+	if nf.PciAddresses != nil && len(nf.PciAddresses) > 0 {
+		if selector, err := rf.GetSelector("pciAddresses", nf.PciAddresses); err == nil {
 			filteredDevice = selector.Filter(filteredDevice)
 		}
 	}
 
-	// filter by pciAddresses list
-	if nf.PciAddresses != nil && len(nf.PciAddresses) > 0 {
-		if selector, err := rf.GetSelector("pciAddresses", nf.PciAddresses); err == nil {
+	// filter by PfNames list
+	if nf.PfNames != nil && len(nf.PfNames) > 0 {
+		if selector, err := rf.GetSelector("pfNames", nf.PfNames); err == nil {
 			filteredDevice = selector.Filter(filteredDevice)
 		}
 	}

--- a/pkg/netdevice/netDeviceProvider.go
+++ b/pkg/netdevice/netDeviceProvider.go
@@ -156,6 +156,13 @@ func (np *netDeviceProvider) GetFilteredDevices(devices []types.PciDevice, rc *t
 		}
 	}
 
+	// filter by pciAddresses list
+	if nf.PciAddresses != nil && len(nf.PciAddresses) > 0 {
+		if selector, err := rf.GetSelector("pciAddresses", nf.PciAddresses); err == nil {
+			filteredDevice = selector.Filter(filteredDevice)
+		}
+	}
+
 	// filter by linkTypes list
 	if nf.LinkTypes != nil && len(nf.LinkTypes) > 0 {
 		if len(nf.LinkTypes) > 1 {

--- a/pkg/netdevice/netDeviceProvider_test.go
+++ b/pkg/netdevice/netDeviceProvider_test.go
@@ -113,6 +113,7 @@ var _ = Describe("NetDeviceProvider", func() {
 				de := []string{"abcd", "123a", "abcd", "2222", "1024"}
 				md := []string{"igb_uio", "igb_uio", "igb_uio", "iavf", "vfio-pci"}
 				pf := []string{"eth0", "eth0", "eth1", "net0", "net0"}
+				pa := []string{"0000:03:02.0", "0000:03:02.1", "0000:03:02.2", "0000:03:02.3", "0000:03:02.4"}
 				lt := []string{"ether", "infiniband", "ether", "ether", "fake"}
 				dd := []string{"E710 PPPoE and PPPoL2TPv2", "fake", "fake", "gtp", "profile"}
 				rd := []bool{false, true, false, false, true}
@@ -128,6 +129,7 @@ var _ = Describe("NetDeviceProvider", func() {
 						On("GetDeviceCode").Return(de[i]).
 						On("GetDriver").Return(md[i]).
 						On("GetPFName").Return(pf[i]).
+						On("GetPciAddr").Return(pa[i]).
 						On("GetLinkType").Return(lt[i]).
 						On("GetDDPProfiles").Return(dd[i])
 
@@ -149,6 +151,7 @@ var _ = Describe("NetDeviceProvider", func() {
 					{"devices", &types.NetDeviceSelectors{DeviceSelectors: types.DeviceSelectors{Devices: []string{"abcd"}}}, []types.PciDevice{all[0], all[2]}},
 					{"drivers", &types.NetDeviceSelectors{DeviceSelectors: types.DeviceSelectors{Drivers: []string{"igb_uio"}}}, []types.PciDevice{all[0], all[1], all[2]}},
 					{"pfNames", &types.NetDeviceSelectors{PfNames: []string{"net0", "eth1"}}, []types.PciDevice{all[2], all[3], all[4]}},
+					{"pciAddresses", &types.NetDeviceSelectors{PciAddresses: []string{"0000:03:02.0", "0000:03:02.3"}}, []types.PciDevice{all[0], all[3]}},
 					{"linkTypes", &types.NetDeviceSelectors{LinkTypes: []string{"infiniband"}}, []types.PciDevice{all[1]}},
 					{"linkTypes multi", &types.NetDeviceSelectors{LinkTypes: []string{"infiniband", "fake"}}, []types.PciDevice{all[1], all[4]}},
 					{"ddpProfiles", &types.NetDeviceSelectors{DDPProfiles: []string{"E710 PPPoE and PPPoL2TPv2"}}, []types.PciDevice{all[0]}},

--- a/pkg/netdevice/netDeviceProvider_test.go
+++ b/pkg/netdevice/netDeviceProvider_test.go
@@ -112,8 +112,8 @@ var _ = Describe("NetDeviceProvider", func() {
 				ve := []string{"8086", "8086", "1111", "2222", "3333"}
 				de := []string{"abcd", "123a", "abcd", "2222", "1024"}
 				md := []string{"igb_uio", "igb_uio", "igb_uio", "iavf", "vfio-pci"}
-				pf := []string{"eth0", "eth0", "eth1", "net0", "net0"}
 				pa := []string{"0000:03:02.0", "0000:03:02.1", "0000:03:02.2", "0000:03:02.3", "0000:03:02.4"}
+				pf := []string{"eth0", "eth0", "eth1", "net0", "net0"}
 				lt := []string{"ether", "infiniband", "ether", "ether", "fake"}
 				dd := []string{"E710 PPPoE and PPPoL2TPv2", "fake", "fake", "gtp", "profile"}
 				rd := []bool{false, true, false, false, true}
@@ -128,8 +128,8 @@ var _ = Describe("NetDeviceProvider", func() {
 						On("GetVendor").Return(ve[i]).
 						On("GetDeviceCode").Return(de[i]).
 						On("GetDriver").Return(md[i]).
-						On("GetPFName").Return(pf[i]).
 						On("GetPciAddr").Return(pa[i]).
+						On("GetPFName").Return(pf[i]).
 						On("GetLinkType").Return(lt[i]).
 						On("GetDDPProfiles").Return(dd[i])
 
@@ -150,8 +150,8 @@ var _ = Describe("NetDeviceProvider", func() {
 					{"vendors", &types.NetDeviceSelectors{DeviceSelectors: types.DeviceSelectors{Vendors: []string{"8086"}}}, []types.PciDevice{all[0], all[1]}},
 					{"devices", &types.NetDeviceSelectors{DeviceSelectors: types.DeviceSelectors{Devices: []string{"abcd"}}}, []types.PciDevice{all[0], all[2]}},
 					{"drivers", &types.NetDeviceSelectors{DeviceSelectors: types.DeviceSelectors{Drivers: []string{"igb_uio"}}}, []types.PciDevice{all[0], all[1], all[2]}},
+					{"pciAddresses", &types.NetDeviceSelectors{DeviceSelectors: types.DeviceSelectors{PciAddresses: []string{"0000:03:02.0", "0000:03:02.3"}}}, []types.PciDevice{all[0], all[3]}},
 					{"pfNames", &types.NetDeviceSelectors{PfNames: []string{"net0", "eth1"}}, []types.PciDevice{all[2], all[3], all[4]}},
-					{"pciAddresses", &types.NetDeviceSelectors{PciAddresses: []string{"0000:03:02.0", "0000:03:02.3"}}, []types.PciDevice{all[0], all[3]}},
 					{"linkTypes", &types.NetDeviceSelectors{LinkTypes: []string{"infiniband"}}, []types.PciDevice{all[1]}},
 					{"linkTypes multi", &types.NetDeviceSelectors{LinkTypes: []string{"infiniband", "fake"}}, []types.PciDevice{all[1], all[4]}},
 					{"ddpProfiles", &types.NetDeviceSelectors{DDPProfiles: []string{"E710 PPPoE and PPPoL2TPv2"}}, []types.PciDevice{all[0]}},

--- a/pkg/resources/deviceSelectors.go
+++ b/pkg/resources/deviceSelectors.go
@@ -68,6 +68,25 @@ func (s *driverSelector) Filter(inDevices []types.PciDevice) []types.PciDevice {
 	return filteredList
 }
 
+// NewPciAddressSelector returns a NetDevSelector interface for netDev list
+func NewPciAddressSelector(pciAddresses []string) types.DeviceSelector {
+	return &pciAddressSelector{pciAddresses: pciAddresses}
+}
+
+type pciAddressSelector struct {
+	pciAddresses []string
+}
+
+func (s *pciAddressSelector) Filter(inDevices []types.PciDevice) []types.PciDevice {
+	filteredList := make([]types.PciDevice, 0)
+	for _, dev := range inDevices {
+		if contains(s.pciAddresses, dev.GetPciAddr()) {
+			filteredList = append(filteredList, dev)
+		}
+	}
+	return filteredList
+}
+
 // NewPfNameSelector returns a NetDevSelector interface for netDev list
 func NewPfNameSelector(pfNames []string) types.DeviceSelector {
 	return &pfNameSelector{pfNames: pfNames}
@@ -136,25 +155,6 @@ func (s *pfNameSelector) Filter(inDevices []types.PciDevice) []types.PciDevice {
 		}
 	}
 
-	return filteredList
-}
-
-// NewPciAddressSelector returns a NetDevSelector interface for netDev list
-func NewPciAddressSelector(pciAddresses []string) types.DeviceSelector {
-	return &pciAddressSelector{pciAddresses: pciAddresses}
-}
-
-type pciAddressSelector struct {
-	pciAddresses []string
-}
-
-func (s *pciAddressSelector) Filter(inDevices []types.PciDevice) []types.PciDevice {
-	filteredList := make([]types.PciDevice, 0)
-	for _, dev := range inDevices {
-		if contains(s.pciAddresses, dev.GetPciAddr()) {
-			filteredList = append(filteredList, dev)
-		}
-	}
 	return filteredList
 }
 

--- a/pkg/resources/deviceSelectors.go
+++ b/pkg/resources/deviceSelectors.go
@@ -139,6 +139,25 @@ func (s *pfNameSelector) Filter(inDevices []types.PciDevice) []types.PciDevice {
 	return filteredList
 }
 
+// NewPciAddressSelector returns a NetDevSelector interface for netDev list
+func NewPciAddressSelector(pciAddresses []string) types.DeviceSelector {
+	return &pciAddressSelector{pciAddresses: pciAddresses}
+}
+
+type pciAddressSelector struct {
+	pciAddresses []string
+}
+
+func (s *pciAddressSelector) Filter(inDevices []types.PciDevice) []types.PciDevice {
+	filteredList := make([]types.PciDevice, 0)
+	for _, dev := range inDevices {
+		if contains(s.pciAddresses, dev.GetPciAddr()) {
+			filteredList = append(filteredList, dev)
+		}
+	}
+	return filteredList
+}
+
 // NewLinkTypeSelector returns a interface for netDev list
 func NewLinkTypeSelector(linkTypes []string) types.DeviceSelector {
 	return &linkTypeSelector{linkTypes: linkTypes}

--- a/pkg/resources/deviceSelectors_test.go
+++ b/pkg/resources/deviceSelectors_test.go
@@ -88,6 +88,38 @@ var _ = Describe("DeviceSelectors", func() {
 			})
 		})
 	})
+	Describe("pciAddress selector", func() {
+		/*Context("initializing", func() {
+			It("should populate pciAddresses array", func() {
+				pciAddr := []string{"0000:03:02.0", "0000:03:02.1"}
+				sel := resources.NewPciAddressSelector(pciAddr).(*pciAddressSelector)
+				Expect(sel.pciAddresses).To(ConsistOf(pciAddr))
+			})
+		})*/
+		Context("filtering", func() {
+			It("should return devices matching on VF pci addresses", func() {
+				pciAddr := []string{"0000:03:02.0", "0000:03:02.1"}
+				sel := resources.NewPciAddressSelector(pciAddr)
+
+				dev0 := mocks.PciNetDevice{}
+				dev0.On("GetPciAddr").Return("0000:03:02.0")
+				dev1 := mocks.PciNetDevice{}
+				dev1.On("GetPciAddr").Return("0000:03:02.1")
+				dev2 := mocks.PciNetDevice{}
+				dev2.On("GetPciAddr").Return("0000:03:02.2")
+				dev3 := mocks.PciNetDevice{}
+				dev3.On("GetPciAddr").Return("0000:03:02.3")
+
+				in := []types.PciDevice{&dev0, &dev1, &dev2, &dev3}
+				filtered := sel.Filter(in)
+
+				Expect(filtered).To(ContainElement(&dev0))
+				Expect(filtered).To(ContainElement(&dev1))
+				Expect(filtered).NotTo(ContainElement(&dev2))
+				Expect(filtered).NotTo(ContainElement(&dev3))
+			})
+		})
+	})
 	Describe("pfName selector", func() {
 		/*Context("initializing", func() {
 			It("should populate ifnames array", func() {
@@ -150,39 +182,6 @@ var _ = Describe("DeviceSelectors", func() {
 				Expect(filtered).To(ContainElement(&dev8))
 				Expect(filtered).NotTo(ContainElement(&dev9))
 				Expect(filtered).To(ContainElement(&dev10))
-			})
-		})
-	})
-
-	Describe("pciAddress selector", func() {
-		/*Context("initializing", func() {
-			It("should populate pciAddresses array", func() {
-				pciAddr := []string{"0000:03:02.0", "0000:03:02.1"}
-				sel := resources.NewPciAddressSelector(pciAddr).(*pciAddressSelector)
-				Expect(sel.pciAddresses).To(ConsistOf(pciAddr))
-			})
-		})*/
-		Context("filtering", func() {
-			It("should return devices matching on VF pci addresses", func() {
-				pciAddr := []string{"0000:03:02.0", "0000:03:02.1"}
-				sel := resources.NewPciAddressSelector(pciAddr)
-
-				dev0 := mocks.PciNetDevice{}
-				dev0.On("GetPciAddr").Return("0000:03:02.0")
-				dev1 := mocks.PciNetDevice{}
-				dev1.On("GetPciAddr").Return("0000:03:02.1")
-				dev2 := mocks.PciNetDevice{}
-				dev2.On("GetPciAddr").Return("0000:03:02.2")
-				dev3 := mocks.PciNetDevice{}
-				dev3.On("GetPciAddr").Return("0000:03:02.3")
-
-				in := []types.PciDevice{&dev0, &dev1, &dev2, &dev3}
-				filtered := sel.Filter(in)
-
-				Expect(filtered).To(ContainElement(&dev0))
-				Expect(filtered).To(ContainElement(&dev1))
-				Expect(filtered).NotTo(ContainElement(&dev2))
-				Expect(filtered).NotTo(ContainElement(&dev3))
 			})
 		})
 	})

--- a/pkg/resources/deviceSelectors_test.go
+++ b/pkg/resources/deviceSelectors_test.go
@@ -154,6 +154,39 @@ var _ = Describe("DeviceSelectors", func() {
 		})
 	})
 
+	Describe("pciAddress selector", func() {
+		/*Context("initializing", func() {
+			It("should populate pciAddresses array", func() {
+				pciAddr := []string{"0000:03:02.0", "0000:03:02.1"}
+				sel := resources.NewPciAddressSelector(pciAddr).(*pciAddressSelector)
+				Expect(sel.pciAddresses).To(ConsistOf(pciAddr))
+			})
+		})*/
+		Context("filtering", func() {
+			It("should return devices matching on VF pci addresses", func() {
+				pciAddr := []string{"0000:03:02.0", "0000:03:02.1"}
+				sel := resources.NewPciAddressSelector(pciAddr)
+
+				dev0 := mocks.PciNetDevice{}
+				dev0.On("GetPciAddr").Return("0000:03:02.0")
+				dev1 := mocks.PciNetDevice{}
+				dev1.On("GetPciAddr").Return("0000:03:02.1")
+				dev2 := mocks.PciNetDevice{}
+				dev2.On("GetPciAddr").Return("0000:03:02.2")
+				dev3 := mocks.PciNetDevice{}
+				dev3.On("GetPciAddr").Return("0000:03:02.3")
+
+				in := []types.PciDevice{&dev0, &dev1, &dev2, &dev3}
+				filtered := sel.Filter(in)
+
+				Expect(filtered).To(ContainElement(&dev0))
+				Expect(filtered).To(ContainElement(&dev1))
+				Expect(filtered).NotTo(ContainElement(&dev2))
+				Expect(filtered).NotTo(ContainElement(&dev3))
+			})
+		})
+	})
+
 	Describe("linkType selector", func() {
 		/*Context("initializing", func() {
 			It("should populate linkTypes array", func() {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -81,19 +81,19 @@ type ResourceConfig struct {
 
 // DeviceSelectors contains common device selectors fields
 type DeviceSelectors struct {
-	Vendors []string `json:"vendors,omitempty"`
-	Devices []string `json:"devices,omitempty"`
-	Drivers []string `json:"drivers,omitempty"`
+	Vendors      []string `json:"vendors,omitempty"`
+	Devices      []string `json:"devices,omitempty"`
+	Drivers      []string `json:"drivers,omitempty"`
+	PciAddresses []string `json:"pciAddresses,omitempty"`
 }
 
 // NetDeviceSelectors contains network device related selectors fields
 type NetDeviceSelectors struct {
 	DeviceSelectors
-	PfNames      []string `json:"pfNames,omitempty"`
-	PciAddresses []string `json:"pciAddresses,omitempty"`
-	LinkTypes    []string `json:"linkTypes,omitempty"`
-	DDPProfiles  []string `json:"ddpProfiles,omitempty"`
-	IsRdma       bool     // the resource support rdma
+	PfNames     []string `json:"pfNames,omitempty"`
+	LinkTypes   []string `json:"linkTypes,omitempty"`
+	DDPProfiles []string `json:"ddpProfiles,omitempty"`
+	IsRdma      bool     // the resource support rdma
 }
 
 // AccelDeviceSelectors contains accelerator(FPGA etc.) related selectors fields

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -89,10 +89,11 @@ type DeviceSelectors struct {
 // NetDeviceSelectors contains network device related selectors fields
 type NetDeviceSelectors struct {
 	DeviceSelectors
-	PfNames     []string `json:"pfNames,omitempty"`
-	LinkTypes   []string `json:"linkTypes,omitempty"`
-	DDPProfiles []string `json:"ddpProfiles,omitempty"`
-	IsRdma      bool     // the resource support rdma
+	PfNames      []string `json:"pfNames,omitempty"`
+	PciAddresses []string `json:"pciAddresses,omitempty"`
+	LinkTypes    []string `json:"linkTypes,omitempty"`
+	DDPProfiles  []string `json:"ddpProfiles,omitempty"`
+	IsRdma       bool     // the resource support rdma
 }
 
 // AccelDeviceSelectors contains accelerator(FPGA etc.) related selectors fields


### PR DESCRIPTION
This makes device plugin to support VM usecase in which
vf (or) virtio devices can be enumerated into a device
pool using its pci addresses.

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>