### PR TITLE
SRIOV support for non-network device (FEC)

### DIFF
--- a/cmd/sriovdp/manager.go
+++ b/cmd/sriovdp/manager.go
@@ -32,6 +32,7 @@ import (
 const (
 	socketSuffix = "sock"
 	netClass     = 0x02 // Device class - Network controller.	 ref: https://pci-ids.ucw.cz/read/PD/02 (for Sub-Classes)
+	fecClass     = 0x12 // Device class - Processing accelerator
 )
 
 /*
@@ -46,6 +47,7 @@ Network controller subclasses. ref: https://pci-ids.ucw.cz/read/PD/02
 		07	Infiniband controller
 		08	Fabric controller
 		80	Network controller
+		12  Processing Accelerator
 */
 
 type cliParams struct {
@@ -194,8 +196,8 @@ func (rm *resourceManager) discoverHostDevices() error {
 			continue
 		}
 
-		// only interested in network class
-		if devClass == netClass {
+		// only interested in network class + patch for detecting FEC processing accelerator
+		if devClass == netClass || devClass == fecClass {
 			vendor := device.Vendor
 			vendorName := vendor.Name
 			if len(vendor.Name) > 20 {
@@ -208,28 +210,57 @@ func (rm *resourceManager) discoverHostDevices() error {
 			}
 			glog.Infof("discoverDevices(): device found: %-12s\t%-12s\t%-20s\t%-40s", device.Address, device.Class.ID, vendorName, productName)
 
-			// exclude device in-use in host
-			if isDefaultRoute, _ := hasDefaultRoute(device.Address); !isDefaultRoute {
+			// Network devices
+			if devClass == netClass {
+				// exclude device in-use in host
+				if isDefaultRoute, _ := hasDefaultRoute(device.Address); !isDefaultRoute {
 
+					aPF := utils.IsSriovPF(device.Address)
+					aVF := utils.IsSriovVF(device.Address)
+
+					if aPF || !aVF {
+						// add to linkWatchList
+						rm.addToLinkWatchList(device.Address)
+					}
+
+					if aPF && utils.SriovConfigured(device.Address) {
+						// do not add this device in net device list
+						continue
+					}
+
+					if newDevice, err := resources.NewPciNetDevice(device, rm.rFactory); err == nil {
+						rm.netDeviceList = append(rm.netDeviceList, newDevice)
+					} else {
+						glog.Errorf("discoverDevices() error adding new device: %q", err)
+					}
+
+				}
+			}
+
+			// FEC processing accelerators
+			if devClass == fecClass {
+				//Check if device is a physical function (PF)
 				aPF := utils.IsSriovPF(device.Address)
-				aVF := utils.IsSriovVF(device.Address)
 
-				if aPF || !aVF {
-					// add to linkWatchList
-					rm.addToLinkWatchList(device.Address)
-				}
+				//If dev ID = 0b30 it means it is a RSU device and not FEC
+				if device.Product.ID != "0b30" {
+					if aPF && utils.SriovConfigured(device.Address) {
+						// If it is a PF and SRIOV is configured do not add to device list
+						continue
+					}
 
-				if aPF && utils.SriovConfigured(device.Address) {
-					// do not add this device in net device list
-					continue
-				}
-
-				if newDevice, err := resources.NewPciNetDevice(device, rm.rFactory); err == nil {
-					rm.netDeviceList = append(rm.netDeviceList, newDevice)
+					if newDevice, err := resources.NewPciNetDevice(device, rm.rFactory); err == nil {
+						if newDevice.GetDriver() == "igb_uio" || newDevice.GetDriver() == "vfio-pci" {
+							rm.netDeviceList = append(rm.netDeviceList, newDevice)
+						} else {
+							glog.Infof("Excluding FEC device %-12s because it is not bound to userspace driver.", device.Address)
+						}
+					} else {
+						glog.Errorf("discoverDevices() error adding new device: %q", err)
+					}
 				} else {
-					glog.Errorf("discoverDevices() error adding new device: %q", err)
+					glog.Infof("Excluding device %-12s , it is a RSU device.", device.Address)
 				}
-
 			}
 		}
 	}


### PR DESCRIPTION
SRIOV feature is not just applicable for Network interfaces but any IO device that support PCIe SIG SRIOV features. One such device is based on Intel® PAC N3000 FPGA which has Network Functionality of 2x25G and FPGA part that can be programmed to support hardware offload of the  Wireless (4G/5G) Forward Error Correction (FEC). This Product has already been released by Intel and is being used/deployed by customers. Intel FPGA Device plugin (https://github.com/intel/intel-device-plugins-for-kubernetes/blob/master/cmd/fpga_plugin/README.md) does not support such devices as it dose not cover SRIOV devices using DPDK and also differ in the FPGA image that gets programmed. As part of this PR we are recommending to extend the SRIOV support for non-networking devices and also rename the device plugin from “sriov-network-device-plugin” to “sriov-device-plugin”. For the Intel® PAC N3000 FPGA supporting vRAN or Cloud-native RAN the FPGA PF that supports FEC is bound to DPDK igb_uio or vfio_pci. The Virtual Function resources are allocated to the PODs running RAN/FlexRAN like workload and uses vfio_pci.