### PR TITLE
add ddp selector

### DIFF
--- a/cmd/sriovdp/manager.go
+++ b/cmd/sriovdp/manager.go
@@ -328,6 +328,16 @@ func (rm *resourceManager) getFilteredDevices(rc *types.ResourceConfig) []types.
 		}
 	}
 
+	// filter by linkTypes list
+	if rc.Selectors.LinkTypes != nil && len(rc.Selectors.LinkTypes) > 0 {
+		if len(rc.Selectors.LinkTypes) > 1 {
+			glog.Warningf("Link type selector should have a single value.")
+		}
+		if selector, err := rf.GetSelector("linkTypes", rc.Selectors.LinkTypes); err == nil {
+			filteredDevice = selector.Filter(filteredDevice)
+		}
+	}
+
 	// filter by DDP Profiles list
 	if rc.Selectors.DDPProfiles != nil && len(rc.Selectors.DDPProfiles) > 0 {
 		if selector, err := rf.GetSelector("ddpProfiles", rc.Selectors.DDPProfiles); err == nil {

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,3 +4,4 @@ This page contains supplimentary documention that users may find useful for vari
 * [Running DPDK application in Kubernetes](dpdk/)
 * [Using UDEV Rules for changing NIC's network device name](udev/)
 * [Running RDMA application in Kubernetes](rdma/)
+* [SR-IOV network device plugin with DDP](ddp/)

--- a/docs/ddp/README.md
+++ b/docs/ddp/README.md
@@ -1,0 +1,186 @@
+
+
+# SR-IOV network device plugin with DDP
+Dynamic Device Personalization aka DDP allows dynamic reconfiguration of the packet processing pipeline of Intel Ethernet 700 Series to meet specific use case needs on demand, adding new packet processing pipeline configuration *profiles* to a network adapter at run time, without resetting or rebooting the server.
+
+(ref: [Dynamic Device Personalization for Intel® Ethernet 700 Series](https://software.intel.com/en-us/articles/dynamic-device-personalization-for-intel-ethernet-700-series))
+
+The SR-IOV network device plugin could be used to identify currently running DDP *profiles*, thus allow it to filter Virtual Functions by their DDP profile names.
+
+The Intel Ethernet 700 Series, a DDP profiles can be loaded/unloaded into the NIC using i40e kernel module(v2.7.26+) and ethtool OR using DPDK i40e pollmode driver & DPDK api. In this documentation we will cover i40e Kernel driver mode.
+
+## Pre-requisites
+ * Firmware: v6.01 or newer
+ * Driver: i40e v2.7.26 or newer
+
+Refer to [Intel downloadcenter](https://downloadcenter.intel.com/) for latest firmware and drivers for Intel Ethernet 700 Series.
+
+You can use `ethtool` to get driver and firmware information of the controller.
+
+```
+# ethtool -i enp2s0f0
+driver: i40e
+version: 2.9.21
+firmware-version: 7.00 0x80004cda 1.2154.0
+expansion-rom-version:
+bus-info: 0000:02:00.0
+supports-statistics: yes
+supports-test: yes
+supports-eeprom-access: yes
+supports-register-dump: yes
+supports-priv-flags: yes
+```
+
+## 1. Install DDP profiles
+On each node, download and extract desired DDP profiles into `/lib/firmware/intel/i40e/ddp/` directory.
+
+The latest list of available packages can be found [here]( https://downloadcenter.intel.com/search?keyword=Dynamic+Device+Personalization).
+
+For example, to download and extract the GTP profile:
+
+```
+$ wget https://downloadmirror.intel.com/27587/eng/gtp.zip
+$ unzip gtp.zip
+$ mkdir -pv /lib/firmware/intel/i40e/ddp
+$ cp gtp.pkgo /lib/firmware/intel/i40e/ddp/
+```
+
+## 2. Load a DDP profile in to the NIC
+
+Use Linux `ethtool` utility to load a DDP profile into the controller.
+> Note: You can only load DDP profile into a controller using only first Physical Function(PF0).
+```
+$ ethtool -f enp2s0f0 gtp.pkgo 100
+```
+## 3. Create SR-IOV Virtual Functions
+
+Create desired number of VFs using PF interfaces of the controller.
+
+```
+$ echo 2 > /sys/class/net/enp2s0f0/device/sriov_numvfs
+
+```
+
+## 4. Verify that correct profile is loaded
+You can use another Linux utility for Intel 700 Series called `ddptool` to query current DDP profile information. This tool can downloaded from [here]( https://downloads.sourceforge.net/project/e1000/ddptool%20stable/ddptool-1.0.0.0/ddptool-1.0.0.0.tar.gz).
+
+```
+[root@silpixa00396659 ~]# ddptool -a
+Intel(R) Dynamic Device Personalization Tool
+DDPTool version 1.0.0.0
+Copyright (C) 2019 Intel Corporation.
+
+NIC  DevId D:B:S.F      DevName         TrackId  Version      Name
+==== ===== ============ =============== ======== ============ ==============================
+001) 1572  0000:02:00.0 enp2s0f0        80000008 1.0.3.0      GTPv1-C/U IPv4/IPv6 payload
+002) 1572  0000:02:00.1 enp2s0f1        80000008 1.0.3.0      GTPv1-C/U IPv4/IPv6 payload
+003) 1572  0000:02:00.2 enp2s0f2        80000008 1.0.3.0      GTPv1-C/U IPv4/IPv6 payload
+004) 1572  0000:02:00.3 enp2s0f3        80000008 1.0.3.0      GTPv1-C/U IPv4/IPv6 payload
+005) 154C  0000:03:02.0 N/A             80000008 1.0.3.0      GTPv1-C/U IPv4/IPv6 payload
+006) 154C  0000:03:02.1 enp3s2f1        80000008 1.0.3.0      GTPv1-C/U IPv4/IPv6 payload
+007) 154C  0000:03:02.2 enp3s2f2        80000008 1.0.3.0      GTPv1-C/U IPv4/IPv6 payload
+008) 154C  0000:03:02.3 N/A             80000008 1.0.3.0      GTPv1-C/U IPv4/IPv6 payload
+```
+
+Take note of the `Name` of the profile from ddptool output. This name will be used in `"ddpProfiles"` selector in plugin's resource pool configurations.
+
+## 5. Create resource config with DDP profile selector
+
+Create ConfigMap for device plugin:
+
+```
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sriovdp-config
+  namespace: kube-system
+data:
+  config.json: |
+    {
+        "resourceList": [{
+                "resourceName": "x700_gtp",
+                "selectors": {
+                    "vendors": ["8086"],
+                    "devices": ["154c"],
+                    "ddpProfiles": ["GTPv1-C/U IPv4/IPv6 payload"]
+                }
+            },
+            {
+                "resourceName": "x700_pppoe",
+                "selectors": {
+                    "vendors": ["8086"],
+                    "devices": ["154c"],
+                    "ddpProfiles": ["E710 PPPoE and PPPoL2TPv2"]
+                }
+            }
+        ]
+    }
+
+```
+
+```
+$ kubectl create -f configMap.yaml
+```
+
+## 6. Deploy SR-IOV network device plugin
+Once the ConfigMap for the device plugin is created/updated you can deploy the SR-IOV network device plugin as [usual](https://github.com/intel/sriov-network-device-plugin#example-deployments). When everything is good, we should see that device plugin is able to discover VFs with DDP profile names given in the resource pool selector.
+
+```
+[root@silpixa00396659 ~]# kubectl get node node1 -o json | jq ".status.allocatable"
+{
+  "cpu": "8",
+  "ephemeral-storage": "169986638772",
+  "hugepages-1Gi": "0",
+  "hugepages-2Mi": "8Gi",
+  "intel.com/x700_gtp": "2",
+  "intel.com/x700_pppoe": "0",
+  "memory": "7880620Ki",
+  "pods": "100"
+}
+
+```
+
+## 7. Create net-attach-def CRs
+This deployment is using Multus and SR-IOV CNI plugin for Pod network attachment of SR-IOV VFs. For this, we need to create a new net-attach-def CR that reference to the new resource pool.
+
+```
+$ cat crd-sriov-gtp.yaml
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: sriov-net-gtp
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: intel.com/x700_gtp
+spec:
+  config: '{
+    "cniVersion": "0.3.1",
+    "type": "sriov",
+    "name": "sriov-gtp",
+    "ipam": {
+      "type": "host-local",
+      "subnet": "10.56.217.0/24",
+      "routes": [{
+        "dst": "0.0.0.0/0"
+      }],
+      "gateway": "10.56.217.1"
+    }
+}'
+```
+
+```
+$ kubectl create -f crd-sriov-gtp.yaml
+```
+
+## 8. Deploy workloads
+Once we can verify that VFs are registered by the device plugin under correct resource pool with specific DDP profile, we can request those VFs from our workload as normal.
+
+```
+$ kubectl create -f pod-gtp.yaml
+```
+
+The sample ConfigMap and Pod specs are available in this directory.
+
+## References
+* https://software.intel.com/en-us/articles/dynamic-device-personalization-for-intel-ethernet-700-series
+* https://www.intel.com/content/www/us/en/architecture-and-technology/ethernet/dynamic-device-personalization-brief.html
+* https://builders.intel.com/docs/networkbuilders/implementing-a-high-performance-bng-with-intel-universal-nfvi-packet-forwarding-platform-technology.pdf

--- a/docs/ddp/README.md
+++ b/docs/ddp/README.md
@@ -5,9 +5,9 @@ Dynamic Device Personalization aka DDP allows dynamic reconfiguration of the pac
 
 (ref: [Dynamic Device Personalization for Intel® Ethernet 700 Series](https://software.intel.com/en-us/articles/dynamic-device-personalization-for-intel-ethernet-700-series))
 
-The SR-IOV network device plugin could be used to identify currently running DDP *profiles*, thus allow it to filter Virtual Functions by their DDP profile names.
+The SR-IOV network device plugin can be used to identify currently running DDP *profiles*, allowing it to filter Virtual Functions by their DDP profile names.
 
-The Intel Ethernet 700 Series, a DDP profiles can be loaded/unloaded into the NIC using i40e kernel module(v2.7.26+) and ethtool OR using DPDK i40e pollmode driver & DPDK api. In this documentation we will cover i40e Kernel driver mode.
+The Intel Ethernet 700 Series, a DDP profile can be loaded/unloaded into the NIC using i40e kernel module(v2.7.26+) and ethtool OR using DPDK i40e pollmode driver & DPDK api. In this documentation we will cover i40e Kernel driver mode.
 
 ## Pre-requisites
  * Firmware: v6.01 or newer
@@ -62,7 +62,7 @@ $ echo 2 > /sys/class/net/enp2s0f0/device/sriov_numvfs
 ```
 
 ## 4. Verify that correct profile is loaded
-You can use another Linux utility for Intel 700 Series called `ddptool` to query current DDP profile information. This tool can downloaded from [here]( https://downloads.sourceforge.net/project/e1000/ddptool%20stable/ddptool-1.0.0.0/ddptool-1.0.0.0.tar.gz).
+You can use another Linux utility for Intel 700 Series called `ddptool` to query current DDP profile information. This tool can be downloaded from [here]( https://downloads.sourceforge.net/project/e1000/ddptool%20stable/ddptool-1.0.0.0/ddptool-1.0.0.0.tar.gz).
 
 ```
 [root@silpixa00396659 ~]# ddptool -a

--- a/docs/ddp/configMap.yaml
+++ b/docs/ddp/configMap.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sriovdp-config
+  namespace: kube-system
+data:
+  config.json: |
+    {
+        "resourceList": [{
+                "resourceName": "x700_gtp",
+                "selectors": {
+                    "vendors": ["8086"],
+                    "devices": ["154c"],
+                    "ddpProfiles": ["GTPv1-C/U IPv4/IPv6 payload"]
+                }
+            },
+            {
+                "resourceName": "x700_pppoe",
+                "selectors": {
+                    "vendors": ["8086"],
+                    "devices": ["154c"],
+                    "ddpProfiles": ["E710 PPPoE and PPPoL2TPv2"]
+                }
+            }
+        ]
+    }

--- a/docs/ddp/crd-sriov-gtp.yaml
+++ b/docs/ddp/crd-sriov-gtp.yaml
@@ -1,0 +1,20 @@
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: sriov-net-gtp
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: intel.com/x700_gtp
+spec:
+  config: '{
+    "cniVersion": "0.3.1",
+    "type": "sriov",
+    "name": "sriov-gtp",
+    "ipam": {
+      "type": "host-local",
+      "subnet": "10.56.217.0/24",
+      "routes": [{
+        "dst": "0.0.0.0/0"
+      }],
+      "gateway": "10.56.217.1"
+    }
+}'

--- a/docs/ddp/crd-sriov-pppoe.yaml
+++ b/docs/ddp/crd-sriov-pppoe.yaml
@@ -1,0 +1,20 @@
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: sriov-net-pppoe
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: intel.com/x700_pppoe
+spec:
+  config: '{
+    "cniVersion": "0.3.1",
+    "type": "sriov",
+    "name": "sriov-pppoe",
+    "ipam": {
+      "type": "host-local",
+      "subnet": "10.56.217.0/24",
+      "routes": [{
+        "dst": "0.0.0.0/0"
+      }],
+      "gateway": "10.56.217.1"
+    }
+}'

--- a/docs/ddp/pod-gtp.yaml
+++ b/docs/ddp/pod-gtp.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: testpod-gtp
+  labels:
+    env: test
+  annotations:
+    k8s.v1.cni.cncf.io/networks: sriov-net-gtp
+spec:
+  containers:
+  - name: gtpcntr1
+    image: centos/tools
+    imagePullPolicy: IfNotPresent
+    command: [ "/bin/bash", "-c", "--" ]
+    args: [ "while true; do sleep 300000; done;" ]
+    resources:
+      requests:
+        intel.com/x700_gtp: 1
+      limits:
+        intel.com/x700_gtp: 1

--- a/docs/ddp/pod-pppoe.yaml
+++ b/docs/ddp/pod-pppoe.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: testpod-pppoe
+  labels:
+    env: test
+  annotations:
+    k8s.v1.cni.cncf.io/networks: sriov-net-pppoe
+spec:
+  containers:
+  - name: pppoecntr1
+    image: centos/tools 
+    imagePullPolicy: IfNotPresent
+    command: [ "/bin/bash", "-c", "--" ]
+    args: [ "while true; do sleep 300000; done;" ]
+    resources:
+      requests:
+        intel.com/x700_pppoe: 1
+      limits:
+        intel.com/x700_pppoe: 1

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,17 +1,20 @@
 FROM golang:alpine as builder
 
 ADD . /usr/src/sriov-network-device-plugin
+ADD extras/ddptool-1.0.0.0 /tmp/ddptool
 
 ENV HTTP_PROXY $http_proxy
 ENV HTTPS_PROXY $https_proxy
 RUN apk add --update --virtual build-dependencies build-base linux-headers && \
     cd /usr/src/sriov-network-device-plugin && \
     make clean && \
-    make build
+    make build && \
+    cd /tmp/ddptool && make
 
 FROM alpine
 RUN apk add hwdata-pci
 COPY --from=builder /usr/src/sriov-network-device-plugin/build/sriovdp /usr/bin/
+COPY --from=builder /tmp/ddptool/ddptool /usr/bin/
 WORKDIR /
 
 LABEL io.k8s.display-name="SRIOV Network Device Plugin"

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:alpine as builder
 
 ADD . /usr/src/sriov-network-device-plugin
-ADD extras/ddptool-1.0.0.0 /tmp/ddptool
+ADD https://downloads.sourceforge.net/project/e1000/ddptool%20stable/ddptool-1.0.0.0/ddptool-1.0.0.0.tar.gz /tmp/ddptool/
 
 ENV HTTP_PROXY $http_proxy
 ENV HTTPS_PROXY $https_proxy
@@ -9,7 +9,7 @@ RUN apk add --update --virtual build-dependencies build-base linux-headers && \
     cd /usr/src/sriov-network-device-plugin && \
     make clean && \
     make build && \
-    cd /tmp/ddptool && make
+    cd /tmp/ddptool && tar zxvf ddptool-1.0.0.0.tar.gz && make
 
 FROM alpine
 RUN apk add hwdata-pci

--- a/pkg/resources/ddpSelector.go
+++ b/pkg/resources/ddpSelector.go
@@ -1,0 +1,27 @@
+package resources
+
+import (
+	"github.com/intel/sriov-network-device-plugin/pkg/types"
+)
+
+type ddpSelector struct {
+	profiles []string
+}
+
+// newDdpSelector returns a DeviceSelector interface to filter devices based on available DDP profile
+func newDdpSelector(profiles []string) types.DeviceSelector {
+	return &ddpSelector{profiles: profiles}
+}
+
+func (ds *ddpSelector) Filter(inDevices []types.PciNetDevice) []types.PciNetDevice {
+	filteredList := make([]types.PciNetDevice, 0)
+
+	for _, dev := range inDevices {
+		ddpProfile := dev.GetDDPProfiles()
+		if ddpProfile != "" && contains(ds.profiles, ddpProfile) {
+			filteredList = append(filteredList, dev)
+		}
+	}
+
+	return filteredList
+}

--- a/pkg/resources/ddpSelector_test.go
+++ b/pkg/resources/ddpSelector_test.go
@@ -1,0 +1,46 @@
+package resources
+
+import (
+	"github.com/intel/sriov-network-device-plugin/pkg/types"
+	"github.com/intel/sriov-network-device-plugin/pkg/types/mocks"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("DdpSelector", func() {
+	Describe("DDP selector", func() {
+		Context("initializing", func() {
+			It("should populate vendors array", func() {
+				profiles := []string{"GTPv1-C", "PPPoE"}
+				sel := newDdpSelector(profiles).(*ddpSelector)
+				Expect(sel.profiles).To(ConsistOf(profiles))
+			})
+		})
+		Context("filtering", func() {
+			It("should return devices matching DDP profiles", func() {
+				profiles := []string{"GTP"}
+				sel := newDdpSelector(profiles).(*ddpSelector)
+
+				dev0 := mocks.PciNetDevice{}
+				dev0.On("GetPciAddr").Return("0000:01:10.0")
+				dev0.On("GetDDPProfiles").Return("GTP")
+
+				dev1 := mocks.PciNetDevice{}
+				dev1.On("GetPciAddr").Return("0000:01:10.1")
+				dev1.On("GetDDPProfiles").Return("PPPoE")
+
+				dev2 := mocks.PciNetDevice{}
+				dev2.On("GetPciAddr").Return("0000:01:10.2")
+				dev2.On("GetDDPProfiles").Return("")
+
+				in := []types.PciNetDevice{&dev0, &dev1}
+				filtered := sel.Filter(in)
+
+				Expect(filtered).To(ContainElement(&dev0))
+				Expect(filtered).NotTo(ContainElement(&dev1))
+				Expect(filtered).NotTo(ContainElement(&dev2))
+			})
+		})
+	})
+})

--- a/pkg/resources/factory.go
+++ b/pkg/resources/factory.go
@@ -81,63 +81,15 @@ func (rf *resourceFactory) GetSelector(attr string, values []string) (types.Devi
 		return newPfNameSelector(values), nil
 	case "linkTypes":
 		return newLinkTypeSelector(values), nil
+	case "ddpProfiles":
+		return newDdpSelector(values), nil
 	default:
 		return nil, fmt.Errorf("GetSelector(): invalid attribute %s", attr)
 	}
 }
 
 // GetResourcePool returns an instance of resourcePool
-func (rf *resourceFactory) GetResourcePool(rc *types.ResourceConfig, deviceList []types.PciNetDevice) (types.ResourcePool, error) {
-	filteredDevice := deviceList
-
-	// filter by vendor list
-	if rc.Selectors.Vendors != nil && len(rc.Selectors.Vendors) > 0 {
-		if selector, err := rf.GetSelector("vendors", rc.Selectors.Vendors); err == nil {
-			filteredDevice = selector.Filter(filteredDevice)
-		}
-	}
-
-	// filter by device list
-	if rc.Selectors.Devices != nil && len(rc.Selectors.Devices) > 0 {
-		if selector, err := rf.GetSelector("devices", rc.Selectors.Devices); err == nil {
-			filteredDevice = selector.Filter(filteredDevice)
-		}
-	}
-
-	// filter by driver list
-	if rc.Selectors.Drivers != nil && len(rc.Selectors.Drivers) > 0 {
-		if selector, err := rf.GetSelector("drivers", rc.Selectors.Drivers); err == nil {
-			filteredDevice = selector.Filter(filteredDevice)
-		}
-	}
-
-	// filter by PfNames list
-	if rc.Selectors.PfNames != nil && len(rc.Selectors.PfNames) > 0 {
-		if selector, err := rf.GetSelector("pfNames", rc.Selectors.PfNames); err == nil {
-			filteredDevice = selector.Filter(filteredDevice)
-		}
-	}
-
-	// filter by linkTypes list
-	if rc.Selectors.LinkTypes != nil && len(rc.Selectors.LinkTypes) > 0 {
-		if len(rc.Selectors.LinkTypes) > 1 {
-			glog.Warningf("Link type selector should have a single value.")
-		}
-		if selector, err := rf.GetSelector("linkTypes", rc.Selectors.LinkTypes); err == nil {
-			filteredDevice = selector.Filter(filteredDevice)
-		}
-	}
-
-	// filter for rdma devices
-	if rc.IsRdma {
-		rdmaDevices := make([]types.PciNetDevice, 0)
-		for _, dev := range filteredDevice {
-			if dev.GetRdmaSpec().IsRdma() {
-				rdmaDevices = append(rdmaDevices, dev)
-			}
-		}
-		filteredDevice = rdmaDevices
-	}
+func (rf *resourceFactory) GetResourcePool(rc *types.ResourceConfig, filteredDevice []types.PciNetDevice) (types.ResourcePool, error) {
 
 	devicePool := make(map[string]types.PciNetDevice, 0)
 	apiDevices := make(map[string]*pluginapi.Device)

--- a/pkg/resources/pciNetDevice.go
+++ b/pkg/resources/pciNetDevice.go
@@ -184,3 +184,12 @@ func (nd *pciNetDevice) GetLinkType() string {
 func (nd *pciNetDevice) GetVFID() int {
 	return nd.vfID
 }
+
+func (nd *pciNetDevice) GetDDPProfiles() string {
+	ddpProfile, err := utils.GetDDPProfiles(nd.pciDevice.Address)
+	if err != nil {
+		glog.Infof("GetDDPProfiles(): unable to get ddp profiles for device %s : %q", nd.pciDevice.Address, err)
+		return ""
+	}
+	return ddpProfile
+}

--- a/pkg/resources/server_test.go
+++ b/pkg/resources/server_test.go
@@ -127,12 +127,13 @@ var _ = Describe("Server", func() {
 			fakeConf = &types.ResourceConfig{
 				ResourceName: "fake",
 				Selectors: struct {
-					Vendors   []string `json:"vendors,omitempty"`
-					Devices   []string `json:"devices,omitempty"`
-					Drivers   []string `json:"drivers,omitempty"`
-					PfNames   []string `json:"pfNames,omitempty"`
-					LinkTypes []string `json:"linkTypes,omitempty"`
-				}{[]string{}, []string{"fakeid"}, []string{}, []string{}, []string{}},
+					Vendors     []string `json:"vendors,omitempty"`
+					Devices     []string `json:"devices,omitempty"`
+					Drivers     []string `json:"drivers,omitempty"`
+					PfNames     []string `json:"pfNames,omitempty"`
+					LinkTypes   []string `json:"linkTypes,omitempty"`
+					DDPProfiles []string `json:"ddpProfiles,omitempty"`
+				}{[]string{}, []string{"fakeid"}, []string{}, []string{}, []string{}, []string{}},
 			}
 			rp = mocks.ResourcePool{}
 			rp.On("GetConfig").Return(fakeConf).

--- a/pkg/types/mocks/PciNetDevice.go
+++ b/pkg/types/mocks/PciNetDevice.go
@@ -27,6 +27,20 @@ func (_m *PciNetDevice) GetAPIDevice() *v1beta1.Device {
 	return r0
 }
 
+// GetDDPProfiles provides a mock function with given fields:
+func (_m *PciNetDevice) GetDDPProfiles() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // GetDeviceCode provides a mock function with given fields:
 func (_m *PciNetDevice) GetDeviceCode() string {
 	ret := _m.Called()

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -36,11 +36,12 @@ type ResourceConfig struct {
 	ResourceName   string `json:"resourceName"`             // the resource name will be added with resource prefix in K8s api
 	IsRdma         bool   // the resource support rdma
 	Selectors      struct {
-		Vendors   []string `json:"vendors,omitempty"`
-		Devices   []string `json:"devices,omitempty"`
-		Drivers   []string `json:"drivers,omitempty"`
-		PfNames   []string `json:"pfNames,omitempty"`
-		LinkTypes []string `json:"linkTypes,omitempty"`
+		Vendors     []string `json:"vendors,omitempty"`
+		Devices     []string `json:"devices,omitempty"`
+		Drivers     []string `json:"drivers,omitempty"`
+		PfNames     []string `json:"pfNames,omitempty"`
+		LinkTypes   []string `json:"linkTypes,omitempty"`
+		DDPProfiles []string `json:"ddpProfiles,omitempty"`
 	} `json:"selectors,omitempty"` // Whether devices have SRIOV virtual function capabilities or not
 }
 
@@ -102,6 +103,7 @@ type PciNetDevice interface {
 	GetAPIDevice() *pluginapi.Device
 	GetRdmaSpec() RdmaSpec
 	GetVFID() int
+	GetDDPProfiles() string
 }
 
 // DeviceInfoProvider is an interface to get Device Plugin API specific device information

--- a/pkg/utils/ddp.go
+++ b/pkg/utils/ddp.go
@@ -1,0 +1,76 @@
+package utils
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+)
+
+/*
+Example output of DDP tool
+$ ./ddptool -l -a -j -s 0000:02:00.0
+{
+        "DDPInventory": {
+                "device": "1572",
+                "address": "0000:02:00.0",
+                "name": "enp2s0f0",
+                "display": "Intel(R) Ethernet Converged Network Adapter X710-4",
+                "DDPpackage": {
+                        "track_id": "80000008",
+                        "version": "1.0.3.0",
+                        "name": "GTPv1-C/U IPv4/IPv6 payload"
+                }
+        }
+}
+
+*/
+
+// DDPInfo is the toplevel container of DDPInventory
+type DDPInfo struct {
+	DDPInventory DDPInventory `json:"DDPInventory"`
+}
+
+// DDPInventory holds a device's DDP information
+type DDPInventory struct {
+	Device     string     `json:"device"`
+	Address    string     `json:"address"`
+	Name       string     `json:"name"`
+	Display    string     `json:"display"`
+	DDPpackage DDPpackage `json:"DDPpackage"`
+}
+
+// DDPpackage holds information about DDP profile itself
+type DDPpackage struct {
+	TrackID string `json:"track_id"`
+	Version string `json:"version"`
+	Name    string `json:"name"`
+}
+
+var ddpExecCommand = exec.Command
+
+// GetDDPProfiles returns running DDP profile name if available
+func GetDDPProfiles(dev string) (string, error) {
+
+	var stdout bytes.Buffer
+	cmd := ddpExecCommand("ddptool", "-l", "-a", "-j", "-s", dev)
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	return getDDPNameFromStdout(stdout.Bytes())
+}
+
+func getDDPNameFromStdout(in []byte) (string, error) {
+	ddpInfo := &DDPInfo{}
+	if err := json.Unmarshal(in, ddpInfo); err != nil {
+		return "", err
+	}
+
+	if ddpInfo.DDPInventory.DDPpackage.Name == "" {
+		return "", fmt.Errorf("DDP profile name not found")
+	}
+
+	return ddpInfo.DDPInventory.DDPpackage.Name, nil
+}

--- a/pkg/utils/ddp_test.go
+++ b/pkg/utils/ddp_test.go
@@ -1,0 +1,201 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+//https://npf.io/2015/06/testing-exec-command
+func FakeExecCommand(outs string, exitCode string) func(string, ...string) *exec.Cmd {
+	return func(command string, args ...string) *exec.Cmd {
+		cs := []string{"-test.run=TestHelperProcess", "--", command}
+		cs = append(cs, args...)
+		cmd := exec.Command(os.Args[0], cs...)
+		cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1",
+			fmt.Sprintf("EXIT_CODE=%s", exitCode),
+			fmt.Sprintf("OUTS=%s", outs)}
+		return cmd
+	}
+}
+
+//https://npf.io/2015/06/testing-exec-command
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	exitCode := 0
+	if val, ok := os.LookupEnv("EXIT_CODE"); ok {
+		if code, err := strconv.ParseInt(val, 10, 0); err == nil && code >= 0 && code < 256 {
+			exitCode = int(code)
+		}
+	}
+
+	fmt.Fprintf(os.Stdout, os.Getenv("OUTS"))
+	os.Exit(exitCode)
+}
+
+var _ = Describe("In the utils package", func() {
+	DescribeTable("Get DDP Profiles",
+		// int value(0-255) in string quote(e.g "0", "127")
+		func(dev, ddpToolOut, want, exitCode string, shouldSucceed bool) {
+			ddpExecCommand = FakeExecCommand(ddpToolOut, exitCode)
+			defer func() { ddpExecCommand = exec.Command }()
+
+			got, err := GetDDPProfiles(dev)
+
+			if shouldSucceed {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(want).To(Equal(got))
+			} else {
+				Expect(err).To(HaveOccurred())
+				Expect(want).To(Equal(got))
+			}
+		},
+		Entry("valid device id and valid output from ddp tool",
+			"0000:af:09.0",
+			`
+			{
+				"DDPInventory": {
+						"device": "154C",
+						"address": "0000:03:02.0",
+						"name": "enp3s2",
+						"display": "Intel(R) Ethernet Virtual Function 700 Series",
+						"DDPpackage": {
+								"track_id": "80000008",
+								"version": "1.0.3.0",
+								"name": "GTPv1-C/U IPv4/IPv6 payload"
+						}
+				}
+		}
+			`,
+			"GTPv1-C/U IPv4/IPv6 payload",
+			"0",
+			true,
+		),
+		Entry("valid device id and unexpected output from ddp tool",
+			"0000:af:09.0",
+			"What ever output",
+			"",
+			"0",
+			false,
+		),
+		Entry("ddp tool command not found",
+			"0000:af:09.0",
+			"",
+			"",
+			"127", // Command not found
+			false,
+		),
+		Entry("ddp tool command not found but stdout matches expected string",
+			"0000:af:09.0",
+			`
+			{
+				"DDPInventory": {
+						"device": "154C",
+						"address": "0000:03:02.0",
+						"name": "enp3s2",
+						"display": "Intel(R) Ethernet Virtual Function 700 Series",
+						"DDPpackage": {
+								"track_id": "80000008",
+								"version": "1.0.3.0",
+								"name": "GTPv1-C/U IPv4/IPv6 payload"
+						}
+				}
+		}
+			`,
+			"",
+			"127",
+			false,
+		),
+		Entry("ddp tool output in alien format",
+			"0000:af:09.0",
+			"02:00.0    enp1s0f0       abcdece      1.0.3.a  GTPv1-C/U IPv4/IPv6 payload",
+			"",
+			"0",
+			false,
+		),
+	)
+
+	DescribeTable("getDDPNameFromStdout",
+		func(ddpToolOut []byte, want string, shouldSucceed bool) {
+
+			got, err := getDDPNameFromStdout(ddpToolOut)
+
+			if shouldSucceed {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(want).To(Equal(got))
+			} else {
+				Expect(err).To(HaveOccurred())
+				Expect(want).To(Equal(got))
+			}
+		},
+		Entry("valid output from ddp tool",
+			[]byte(`
+			{
+				"DDPInventory": {
+						"device": "154C",
+						"address": "0000:03:02.0",
+						"name": "enp3s2",
+						"display": "Intel(R) Ethernet Virtual Function 700 Series",
+						"DDPpackage": {
+								"track_id": "80000008",
+								"version": "1.0.3.0",
+								"name": "GTPv1-C/U IPv4/IPv6 payload"
+						}
+				}
+		}
+			`),
+			"GTPv1-C/U IPv4/IPv6 payload",
+			true,
+		),
+		Entry("valid output from ddp tool but DDPpackage field is missing",
+			[]byte(`
+		{
+			"DDPInventory": {
+					"device": "154C",
+					"address": "0000:03:02.0",
+					"name": "enp3s2",
+					"display": "Intel(R) Ethernet Virtual Function 700 Series"
+			}
+	}
+		`),
+			"",
+			false,
+		),
+		Entry("ddp tool returns error object in json",
+			[]byte(`
+		{"DDPInventory":{
+			"error": "2",
+			"message": "An internal error has occurred"
+		}
+	}
+	`),
+			"",
+			false,
+		),
+		Entry("invalid json output from ddp tool",
+			[]byte(`
+			{"DDPInventory":{
+                "error": "2"
+                "message": "An internal error has occurred"
+        	}
+		}
+		`),
+			"",
+			false,
+		),
+		Entry("random text from ddp tool output",
+			[]byte(``),
+			"",
+			false,
+		),
+	)
+})


### PR DESCRIPTION
Introducing new selector that can filter devices based on the DDP profile a SR-IOV NIC is running with.

For more information on DDP please see [here](https://software.intel.com/en-us/articles/dynamic-device-personalization-for-intel-ethernet-700-series).