### PR TITLE
Add PoolInfo to implement discovery-time pool-specific logic

### DIFF
--- a/pkg/accelerator/accelPoolInfo.go
+++ b/pkg/accelerator/accelPoolInfo.go
@@ -1,0 +1,40 @@
+// Copyright 2020 Red Hat, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package accelerator
+
+import (
+	"github.com/golang/glog"
+	"github.com/intel/sriov-network-device-plugin/pkg/resources"
+	"github.com/intel/sriov-network-device-plugin/pkg/types"
+)
+
+// accelPoolInfo implements PoolDevice interface for Accelerator Devices
+type accelPoolInfo struct {
+	*resources.PoolInfoImpl
+}
+
+// newAccelPoolInfo create a accelPoolInfo
+func newAccelPoolInfo(accelDev types.AccelDevice, rc *types.ResourceConfig, rf types.ResourceFactory) (*accelPoolInfo, error) {
+
+	glog.Infof("Creating accelPoolInfo for AccelDevice: %+v\n", accelDev.GetPciAddr())
+	infoProvider := rf.GetInfoProvider(accelDev.GetDriver())
+	poolInfoImpl, err := resources.NewPoolInfoImpl(accelDev, rc, infoProvider)
+	if err != nil {
+		return nil, err
+	}
+	return &accelPoolInfo{
+		poolInfoImpl,
+	}, nil
+}

--- a/pkg/netdevice/netPoolInfo.go
+++ b/pkg/netdevice/netPoolInfo.go
@@ -1,0 +1,56 @@
+// Copyright 2020 Red Hat, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netdevice
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"github.com/intel/sriov-network-device-plugin/pkg/resources"
+	"github.com/intel/sriov-network-device-plugin/pkg/types"
+)
+
+// netPoolInfo implements PoolDevice interface for Network Devices
+type netPoolInfo struct {
+	*resources.PoolInfoImpl
+}
+
+// newNetPoolInfo creates a netPoolInfo.
+func newNetPoolInfo(netDev types.PciNetDevice, rc *types.ResourceConfig, rf types.ResourceFactory) (*netPoolInfo, error) {
+
+	glog.Infof("Creating netPoolInfo for PciNetDevice: %+v\n", netDev.GetPciAddr())
+	infoProvider := rf.GetInfoProvider(netDev.GetDriver())
+	poolInfoImpl, err := resources.NewPoolInfoImpl(netDev, rc, infoProvider)
+	if err != nil {
+		return nil, err
+	}
+
+	// Append Rdma Specs only if Rdma is in the pool's selectors
+	s, _ := rc.SelectorObj.(*types.NetDeviceSelectors)
+	if s.IsRdma {
+		rdmaSpec := netDev.GetRdmaSpec()
+		if rdmaSpec.IsRdma() {
+			rdmaDeviceSpec := rdmaSpec.GetRdmaDeviceSpec()
+			for _, spec := range rdmaDeviceSpec {
+				poolInfoImpl.DeviceSpecs = append(poolInfoImpl.DeviceSpecs, spec)
+			}
+		} else {
+			return nil, fmt.Errorf("NewNetPoolInfo(): rdma is required in the configuration but the device %v is not an rdma device", netDev.GetPciAddr())
+		}
+	}
+
+	return &netPoolInfo{
+		poolInfoImpl,
+	}, nil
+}

--- a/pkg/resources/poolInfo.go
+++ b/pkg/resources/poolInfo.go
@@ -1,0 +1,77 @@
+package resources
+
+import (
+	"github.com/intel/sriov-network-device-plugin/pkg/types"
+	"github.com/intel/sriov-network-device-plugin/pkg/utils"
+	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
+	"strconv"
+)
+
+// PoolInfoImpl implements PoolInfo interface and can serve as a base class for
+// more advanced device-specific PoolInfo instances
+type PoolInfoImpl struct {
+	PciDev      types.PciDevice
+	Env         string
+	APIDevice   *pluginapi.Device
+	DeviceSpecs []*pluginapi.DeviceSpec
+	Mounts      []*pluginapi.Mount
+}
+
+// NewPoolInfoImpl creates a new PoolInfoImpl with a given DeviceInfoProvider
+func NewPoolInfoImpl(pciDev types.PciDevice, rc *types.ResourceConfig, ip types.DeviceInfoProvider) (*PoolInfoImpl, error) {
+	env := ip.GetEnvVal(pciDev.GetPciAddr())
+	mnt := ip.GetMounts(pciDev.GetPciAddr())
+
+	// Set DeviceSpecs
+	dSpecs := ip.GetDeviceSpecs(pciDev.GetPciAddr())
+	// Create apiDevice
+	apiDevice := &pluginapi.Device{
+		ID:     pciDev.GetPciAddr(),
+		Health: pluginapi.Healthy,
+	}
+	nodeNum := utils.GetDevNode(pciDev.GetPciAddr())
+	if nodeNum >= 0 {
+		numaInfo := &pluginapi.NUMANode{
+			ID: int64(nodeNum),
+		}
+		apiDevice.Topology = &pluginapi.TopologyInfo{
+			Nodes: []*pluginapi.NUMANode{numaInfo},
+		}
+	}
+	return &PoolInfoImpl{
+		PciDev:      pciDev,
+		Env:         env,
+		APIDevice:   apiDevice,
+		DeviceSpecs: dSpecs,
+		Mounts:      mnt,
+	}, nil
+}
+
+// Convert NUMA node number to string.
+// A node of -1 represents "unknown" and is converted to the empty string.
+func nodeToStr(nodeNum int) string {
+	if nodeNum >= 0 {
+		return strconv.Itoa(nodeNum)
+	}
+	return ""
+}
+
+// GetDeviceSpecs returns the Device Specifications
+func (pd *PoolInfoImpl) GetDeviceSpecs() []*pluginapi.DeviceSpec {
+	return pd.DeviceSpecs
+}
+
+// GetEnvVal returns the ENV variable value
+func (pd *PoolInfoImpl) GetEnvVal() string {
+	return pd.Env
+}
+
+// GetMounts returns the Mount list
+func (pd *PoolInfoImpl) GetMounts() []*pluginapi.Mount {
+	return pd.Mounts
+}
+
+// GetAPIDevice returns the API Device
+func (pd *PoolInfoImpl) GetAPIDevice() *pluginapi.Device {
+	return pd.APIDevice
+}

--- a/pkg/resources/pool_stub.go
+++ b/pkg/resources/pool_stub.go
@@ -24,13 +24,13 @@ import (
 type ResourcePoolImpl struct {
 	config     *types.ResourceConfig
 	devices    map[string]*pluginapi.Device
-	devicePool map[string]types.PciDevice
+	devicePool map[string]types.PoolInfo
 }
 
 var _ types.ResourcePool = &ResourcePoolImpl{}
 
 // NewResourcePool returns an instance of resourcePool
-func NewResourcePool(rc *types.ResourceConfig, apiDevices map[string]*pluginapi.Device, devicePool map[string]types.PciDevice) *ResourcePoolImpl {
+func NewResourcePool(rc *types.ResourceConfig, apiDevices map[string]*pluginapi.Device, devicePool map[string]types.PoolInfo) *ResourcePoolImpl {
 	return &ResourcePoolImpl{
 		config:     rc,
 		devices:    apiDevices,
@@ -130,9 +130,4 @@ func (rp *ResourcePoolImpl) DeviceSpecExist(specs []*pluginapi.DeviceSpec, newSp
 		}
 	}
 	return false
-}
-
-// GetDevicePool returns PciDevice pool as a map
-func (rp *ResourcePoolImpl) GetDevicePool() map[string]types.PciDevice {
-	return rp.devicePool
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -150,10 +150,6 @@ type PciDevice interface {
 	GetPciAddr() string
 	IsSriovPF() bool
 	GetSubClass() string
-	GetDeviceSpecs() []*pluginapi.DeviceSpec
-	GetEnvVal() string
-	GetMounts() []*pluginapi.Mount
-	GetAPIDevice() *pluginapi.Device
 	GetVFID() int
 	GetNumaInfo() string
 }
@@ -172,6 +168,14 @@ type PciNetDevice interface {
 // AccelDevice extends PciDevice interface
 type AccelDevice interface {
 	PciDevice
+}
+
+// PoolInfo provides an interface to get the information that will be used by the ResourcePool
+type PoolInfo interface {
+	GetDeviceSpecs() []*pluginapi.DeviceSpec
+	GetEnvVal() string
+	GetMounts() []*pluginapi.Mount
+	GetAPIDevice() *pluginapi.Device
 }
 
 // DeviceInfoProvider is an interface to get Device Plugin API specific device information


### PR DESCRIPTION
This PR is intended to demonstrate #212 and propose a possible implementation (still work in progress).

Firstly, it splits the current PciNetDevice interface into two separate interfaces:
- PciNetDevice for low level device information (used for filtering)
- PoolDevice for providing the information that the ResourcePool needs (i.e: DeviceSpecs, Mounts, Envs, etc)

That way, InfoProviders could be selected based on ResourcePool information.

This is part of my efforts to cleanly implement vdpa support for the Device Plugin.

It can be observed how, with this preliminary rework, an experimental vdpa support can be implemented with little change in existing DP code:
https://github.com/amorenoz/sriov-network-device-plugin/tree/vdpa_pooldev
