### PR TITLE
fix travis deployment script errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - make test
   - make build
   - make
-  - make image
+  - make image TAG="$REGISTRY_USER/sriov-device-plugin"
 
 before_deploy:
   - docker login -u "$REGISTRY_USER" -p "$REGISTRY_PASS"
@@ -29,23 +29,22 @@ deploy:
   - provider: script
     skip_cleanup: true
     script: >
-      if [ "${TARGET}" == "amd64" ]; then
-        docker push nfvpe/sriov-device-plugin;
-      fi
-      docker tag nfvpe/sriov-device-plugin nfvpe/sriov-device-plugin:$ARCH;
-      docker push nfvpe/sriov-device-plugin:$ARCH;
+      bash -c '
+      if [[ "${ARCH}" == "amd64" ]]; then docker push $REGISTRY_USER/sriov-device-plugin; fi;
+      docker tag $REGISTRY_USER/sriov-device-plugin $REGISTRY_USER/sriov-device-plugin:$ARCH;
+      docker push $REGISTRY_USER/sriov-device-plugin:$ARCH;
+      echo done'
     on:
       branch: master
   # Push image to Dockerhub on tag
   - provider: script
     skip_cleanup: true
     script: >
-      if [ "${ARCH}" == "amd64" ]; then
-        docker tag nfvpe/sriov-device-plugin nfvpe/sriov-device-plugin:$TRAVIS_TAG;
-        docker push nfvpe/sriov-device-plugin:$TRAVIS_TAG;
-      fi
-      docker tag nfvpe/sriov-device-plugin nfvpe/sriov-device-plugin:$TRAVIS_TAG-$ARCH;
-      docker push nfvpe/sriov-device-plugin:$TRAVIS_TAG-$ARCH;
+      bash -c '
+      if [[ "${ARCH}" == "amd64" ]]; then docker tag $REGISTRY_USER/sriov-device-plugin $REGISTRY_USER/sriov-device-plugin:"$TRAVIS_TAG"; docker push $REGISTRY_USER/sriov-device-plugin:"$TRAVIS_TAG"; fi;
+      docker tag $REGISTRY_USER/sriov-device-plugin $REGISTRY_USER/sriov-device-plugin:"$TRAVIS_TAG-$ARCH";
+      docker push $REGISTRY_USER/sriov-device-plugin:"$TRAVIS_TAG-$ARCH";
+      echo done'
     on:
       tags: true
       all_branches: true


### PR DESCRIPTION
The deployment scripts weren't parsing properly and resulted in
errors.

This change also uses the REGISTRY_USER variable for image tagging
so that deployement can be tested on local forks with their own
REGISTRY_USER value.

Change-Id: Idf03b5c8c256f63ce01beff5c316cb8c5a786db3