### PR TITLE
netdevice: add option to share /dev/vhost-net

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ This plugin creates device plugin endpoints based on the configurations given in
                 "vendors": ["8086"],
                 "devices": ["154c", "10ed"],
                 "drivers": ["vfio-pci"],
-                "pfNames": ["enp0s0f0","enp2s2f1"]
+                "pfNames": ["enp0s0f0","enp2s2f1"],
+                "needVhostNet": true
             }
         },
         {
@@ -249,6 +250,7 @@ This selector is applicable when "deviceType" is "netDevice"(note: this is defau
 | "linkTypes"   | N        | The link type of the net device associated with the PCI device | `string` list Default: `null`                     | "linkTypes": ["ether"]                                                               |
 | "ddpProfiles" | N        | A map of device selectors                                      | `string` list Default: `null`                     | "ddpProfiles": ["GTPv1-C/U IPv4/IPv6 payload"]                                       |
 | "isRdma"      | N        | Mount RDMA resources                                           | `bool`  values `true` or `false` Default: `false` | "isRdma": `true`                                                                     |
+| "needVhostNet"| N        | Share /dev/vhost-net                                           | `bool`  values `true` or `false` Default: `false` | "needVhostNet": `true`                                                               |
 
 
 [//]: # (The tables above generated using: https://ozh.github.io/ascii-tables/)

--- a/pkg/netdevice/netResourcePool.go
+++ b/pkg/netdevice/netResourcePool.go
@@ -61,6 +61,14 @@ func (rp *netResourcePool) GetDeviceSpecs(deviceIDs []string) []*pluginapi.Devic
 					glog.Errorf("GetDeviceSpecs(): rdma is required in the configuration but the device %v is not rdma device", id)
 				}
 			}
+			if rp.selectors.NeedVhostNet {
+				if VhostNetDeviceExist() {
+					vhostNetDeviceSpec := GetVhostNetDeviceSpec()
+					newSpecs = append(newSpecs, vhostNetDeviceSpec...)
+				} else {
+					glog.Errorf("GetDeviceSpecs(): vhost-net is required in the configuration but /dev/vhost-net doesn't exist")
+				}
+			}
 			for _, ds := range newSpecs {
 				if !rp.DeviceSpecExist(devSpecs, ds) {
 					devSpecs = append(devSpecs, ds)

--- a/pkg/netdevice/vhostNet.go
+++ b/pkg/netdevice/vhostNet.go
@@ -1,0 +1,25 @@
+package netdevice
+
+import (
+	"os"
+
+	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+)
+
+// VhostNetDeviceExist returns true if /dev/vhost-net exists
+func VhostNetDeviceExist() bool {
+	_, err := os.Stat("/dev/vhost-net");
+	return err == nil
+}
+
+// GetVhostNetDeviceSpec returns an instance of DeviceSpec for vhost-net
+func GetVhostNetDeviceSpec() []*pluginapi.DeviceSpec {
+	deviceSpec := make([]*pluginapi.DeviceSpec, 0)
+	deviceSpec = append(deviceSpec, &pluginapi.DeviceSpec{
+		HostPath:      "/dev/vhost-net",
+		ContainerPath: "/dev/vhost-net",
+		Permissions:   "mrw",
+	})
+
+	return deviceSpec
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -90,10 +90,11 @@ type DeviceSelectors struct {
 // NetDeviceSelectors contains network device related selectors fields
 type NetDeviceSelectors struct {
 	DeviceSelectors
-	PfNames     []string `json:"pfNames,omitempty"`
-	LinkTypes   []string `json:"linkTypes,omitempty"`
-	DDPProfiles []string `json:"ddpProfiles,omitempty"`
-	IsRdma      bool     // the resource support rdma
+	PfNames      []string `json:"pfNames,omitempty"`
+	LinkTypes    []string `json:"linkTypes,omitempty"`
+	DDPProfiles  []string `json:"ddpProfiles,omitempty"`
+	IsRdma       bool     // the resource support rdma
+	NeedVhostNet bool     // share vhost-net along the selected ressource
 }
 
 // AccelDeviceSelectors contains accelerator(FPGA etc.) related selectors fields


### PR DESCRIPTION
New option to share /dev/vhost-net, useful for dpdk app to implement an
exceptional path.

Let's enable to share this resource along other VF.

Link: https://doc.dpdk.org/guides/howto/virtio_user_as_exceptional_path.html
Signed-off-by: Nicolas Dichtel <nicolas.dichtel@6wind.com>