### PR TITLE
added bond config changes reflecting failOverMac change in bond cni

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,7 @@
 This page contains supplimentary documention that users may find useful for various use-cases with SR-IOV network device plugin.
 
 * [Running DPDK application in Kubernetes](dpdk/)
+* [Providing Failover with a bonded interface in Kubernetes](bond/)
 * [Using UDEV Rules for changing NIC's network device name](udev/)
 * [Running RDMA application in Kubernetes](rdma/)
 * [SR-IOV network device plugin with DDP](ddp/)

--- a/docs/bond/bond-crd.yaml
+++ b/docs/bond/bond-crd.yaml
@@ -9,6 +9,7 @@ spec:
   "name": "bond-net",
   "ifname": "bond0",
   "mode": "active-backup",
+  "failOverMac": 1,
   "linksInContainer": true,
   "miimon": "100",
   "links": [


### PR DESCRIPTION
BKC for bond cni will change as per: https://github.com/intel/bond-cni/pull/15

This doc change reflects that in the bonding guide hosted here.

Waiting for above pull request to be merged before this PR.