### PR TITLE
Use "go clean" to clean modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,7 @@ image: | $(BASE) ; $(info Building Docker image...)
 
 .PHONY: clean
 clean: ; $(info  Cleaning...)	@ ## Cleanup everything
+	@go clean --modcache
 	@rm -rf $(GOPATH)
 	@rm -rf $(BUILDDIR)/$(BINARY_NAME)
 	@rm -rf test/tests.* test/coverage.*


### PR DESCRIPTION
Files downloaded by 'go mod' are not writable (removable).

Use the recommended way of cleaning modules [1]

[1] https://github.com/golang/go/issues/27161#issuecomment-415213240

Fixes #232 
Signed-off-by: Adrian Moreno <amorenoz@redhat.com>