### PR TITLE
fix pfNames selector to skip device with no PF name

### DIFF
--- a/pkg/resources/deviceSelectors.go
+++ b/pkg/resources/deviceSelectors.go
@@ -81,6 +81,10 @@ func (s *pfNameSelector) Filter(inDevices []types.PciDevice) []types.PciDevice {
 	filteredList := make([]types.PciDevice, 0)
 	for _, dev := range inDevices {
 		pfName := dev.(types.PciNetDevice).GetPFName()
+		if pfName == "" {
+			// Exclude devices that doesn't have a PF name
+			continue
+		}
 		selector := getItem(s.pfNames, pfName)
 		if selector != "" {
 			if strings.Contains(selector, "#") {


### PR DESCRIPTION
Current behaviour of pfName selector adds devices that do not have
PF names available. For instance, if there is a PF attached to
igb_uio driver and VFs are created under that PF, those VFs will
have no PF name information. If a resource config prvides the
"pfName" selector any VFs under that PF(igb_uio driver) will
wrongly be added to that pool. This happens because this selector
matches PF name with string.HasPrefix() method and providing ""
for PF name results in true.

Fix: skip devices that do not have PF names when "pfNames" selector
is used.

Change-Id: I1ddd49743ef2e8f25718285e80c16dfcef4c90f5
Signed-off-by: Abdul Halim <abdul.halim@intel.com>